### PR TITLE
Store route blob ID on the DHT and manage route IDs

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -135,7 +135,7 @@ impl Backend {
             .as_ref()
             .ok_or_else(|| anyhow!("Veilid API is not initialized"))?;
         let routing_context = veilid.routing_context()?;
-        let schema = DHTSchema::dflt(1)?;
+        let schema = DHTSchema::dflt(3)?;
         let kind = Some(CRYPTO_KIND_VLD0);
     
         let dht_record = routing_context.create_dht_record(schema, kind).await?;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -13,7 +13,7 @@ use tracing::info;
 use veilid_core::{
     api_startup_config, vld0_generate_keypair, CryptoKey, CryptoSystem, CryptoSystemVLD0,
     CryptoTyped, DHTSchema, KeyPair, ProtectedStore, RoutingContext, SharedSecret, UpdateCallback,
-    VeilidAPI, VeilidConfigInner, VeilidUpdate, CRYPTO_KIND_VLD0, TypedKey
+    VeilidAPI, VeilidConfigInner, VeilidUpdate, CRYPTO_KIND_VLD0, TypedKey, VeilidConfigProtectedStore
 };
 use xdg::BaseDirectories;
 
@@ -128,7 +128,7 @@ impl Backend {
         }
         Ok(())
     }
-
+    
     pub async fn create_group(&mut self) -> Result<Group> {
         let veilid = self
             .veilid_api

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -234,7 +234,7 @@ impl Backend {
             .as_ref()
             .ok_or_else(|| anyhow!("Veilid API is not initialized"))?;
         let routing_context = veilid.routing_context()?;
-        let schema = DHTSchema::dflt(1)?;
+        let schema = DHTSchema::dflt(3)?;
         let kind = Some(CRYPTO_KIND_VLD0);
 
         let dht_record = routing_context.create_dht_record(schema, kind).await?;

--- a/src/common.rs
+++ b/src/common.rs
@@ -100,59 +100,34 @@ pub trait DHTEntity {
         Ok(())
     }
 
-     // Common methods for DHT operations
-    async fn store_route_id_in_dht(&self, subkey: u32, route_id_blob: Vec<u8>) -> Result<()> {
+     async fn store_route_id_in_dht(
+        &self,
+        subkey: u32,
+        route_id_blob: Vec<u8>,
+    ) -> Result<()> {
         let routing_context = &self.get_routing_context();
-    
-        println!("Attempting to open DHT record...");
-    
-        // Open the DHT record using the group's DHT record
-        let dht_record = routing_context
-            .open_dht_record(self.get_dht_record().key().clone(), self.owner_secret().map(|secret| KeyPair::new(self.owner_key(), secret)))
+        let dht_record = self.get_dht_record();
+        routing_context.set_dht_value(
+                dht_record.key().clone(),
+                subkey.into(),
+                route_id_blob,
+                None,
+            )
             .await
-            .map_err(|e| {
-                println!("Failed to open DHT record: {}", e);
-                anyhow!("Failed to open DHT record: {}", e)
-            })?;
-    
-        println!("DHT record opened successfully.");
-    
-        // Set the stored route ID blob at subkey 2
-        routing_context
-            .set_dht_value(self.get_dht_record().key().clone(), 2u32, route_id_blob, self.owner_secret().map(|secret| KeyPair::new(self.owner_key(), secret)))
-            .await
-            .map_err(|e| {
-                println!("Failed to set value in DHT: {}", e);
-                anyhow!("Failed to set value in DHT: {}", e)
-            })?;
-    
-        println!("Value set successfully in DHT.");
-    
-        // Close the DHT record after setting the value
-        routing_context.close_dht_record(self.get_dht_record().key().clone()).await?;
-    
-        println!("DHT record closed successfully.");
-    
+            .map_err(|e| anyhow!("Failed to store route ID blob in DHT: {}", e))?;
+
         Ok(())
     }
     
     async fn get_route_id_from_dht(&self, subkey: u32) -> Result<Vec<u8>> {
         let routing_context = &self.get_routing_context();
         
-        println!("Reopening DHT record before reading...");
-        
-        // Ensure the DHT record is opened before reading
-        let dht_record = routing_context
-            .open_dht_record(self.get_dht_record().key().clone(), self.owner_secret().map(|secret| KeyPair::new(self.owner_key(), secret)))
-            .await
-            .map_err(|e| {
-                println!("Failed to reopen DHT record: {}", e);
-                anyhow!("Failed to reopen DHT record: {}", e)
-            })?;
+        // Use the existing DHT record
+        let dht_record = self.get_dht_record(); 
         
         // Get the stored route ID blob at subkey
         let stored_blob = routing_context
-            .get_dht_value(self.get_dht_record().key().clone(), subkey, false)
+            .get_dht_value(dht_record.key().clone(), subkey, false)
             .await?
             .ok_or_else(|| anyhow!("Route ID blob not found in DHT"))?;
     

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,7 +6,7 @@ use eyre::{Result, anyhow};
 use std::sync::Arc;
 use veilid_core::{
     CryptoKey, SharedSecret, CryptoTyped, DHTRecordDescriptor, RoutingContext, CryptoSystemVLD0,
-    ProtectedStore, Nonce, CRYPTO_KIND_VLD0, CryptoSystem
+    ProtectedStore, Nonce, CRYPTO_KIND_VLD0, CryptoSystem, KeyPair, VeilidAPI
 };
 
 #[derive(Serialize, Deserialize)]
@@ -39,6 +39,16 @@ pub trait DHTEntity {
     fn get_crypto_system(&self) -> CryptoSystemVLD0;
     fn get_dht_record(&self) -> DHTRecordDescriptor;
     fn get_secret_key(&self) -> Option<CryptoKey>;
+
+     // Default method to get the owner key
+     fn owner_key(&self) -> CryptoKey {
+        self.get_dht_record().owner().clone()
+    }
+
+    // Default method to get the owner secret
+    fn owner_secret(&self) -> Option<CryptoKey> {
+        self.get_dht_record().owner_secret().cloned()
+    }
 
     fn encrypt_aead(&self, data: &[u8], associated_data: Option<&[u8]>) -> Result<Vec<u8>> {
         let nonce = self.get_crypto_system().random_nonce();
@@ -90,6 +100,88 @@ pub trait DHTEntity {
         Ok(())
     }
 
+     // Common methods for DHT operations
+    async fn store_route_id_in_dht(&self, subkey: u32, route_id_blob: Vec<u8>) -> Result<()> {
+        let routing_context = &self.get_routing_context();
+    
+        println!("Attempting to open DHT record...");
+    
+        // Open the DHT record using the group's DHT record
+        let dht_record = routing_context
+            .open_dht_record(self.get_dht_record().key().clone(), self.owner_secret().map(|secret| KeyPair::new(self.owner_key(), secret)))
+            .await
+            .map_err(|e| {
+                println!("Failed to open DHT record: {}", e);
+                anyhow!("Failed to open DHT record: {}", e)
+            })?;
+    
+        println!("DHT record opened successfully.");
+    
+        // Set the stored route ID blob at subkey 2
+        routing_context
+            .set_dht_value(self.get_dht_record().key().clone(), 2u32, route_id_blob, self.owner_secret().map(|secret| KeyPair::new(self.owner_key(), secret)))
+            .await
+            .map_err(|e| {
+                println!("Failed to set value in DHT: {}", e);
+                anyhow!("Failed to set value in DHT: {}", e)
+            })?;
+    
+        println!("Value set successfully in DHT.");
+    
+        // Close the DHT record after setting the value
+        routing_context.close_dht_record(self.get_dht_record().key().clone()).await?;
+    
+        println!("DHT record closed successfully.");
+    
+        Ok(())
+    }
+    
+    async fn get_route_id_from_dht(&self, subkey: u32) -> Result<Vec<u8>> {
+        let routing_context = &self.get_routing_context();
+        
+        println!("Reopening DHT record before reading...");
+        
+        // Ensure the DHT record is opened before reading
+        let dht_record = routing_context
+            .open_dht_record(self.get_dht_record().key().clone(), self.owner_secret().map(|secret| KeyPair::new(self.owner_key(), secret)))
+            .await
+            .map_err(|e| {
+                println!("Failed to reopen DHT record: {}", e);
+                anyhow!("Failed to reopen DHT record: {}", e)
+            })?;
+        
+        // Get the stored route ID blob at subkey
+        let stored_blob = routing_context
+            .get_dht_value(self.get_dht_record().key().clone(), subkey, false)
+            .await?
+            .ok_or_else(|| anyhow!("Route ID blob not found in DHT"))?;
+    
+        Ok(stored_blob.data().to_vec())
+    }
+    
+
+    // Send an AppMessage to the repo owner using the stored route ID blob
+    async fn send_message_to_owner(
+        &self,
+        veilid: &VeilidAPI,
+        message: Vec<u8>,
+        subkey: u32,
+    ) -> Result<()> {
+        let routing_context = &self.get_routing_context();
+    
+        // Retrieve the route ID blob from DHT
+        let route_id_blob = self.get_route_id_from_dht(subkey).await?;
+    
+        // Import the route using the blob via VeilidAPI
+        let route_id = veilid.import_remote_private_route(route_id_blob)?;
+    
+        // Send an AppMessage to the repo owner using the imported route ID
+        routing_context
+            .app_message(veilid_core::Target::PrivateRoute(route_id), message)
+            .await?;
+    
+        Ok(())
+    }
     
     fn get_write_key(&self) -> Option<CryptoKey> {
         unimplemented!("WIP")

--- a/src/common.rs
+++ b/src/common.rs
@@ -109,7 +109,7 @@ pub trait DHTEntity {
         let dht_record = self.get_dht_record();
         routing_context.set_dht_value(
                 dht_record.key().clone(),
-                subkey.into(),
+                subkey,
                 route_id_blob,
                 None,
             )

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,7 @@
 #![allow(async_fn_in_trait)]
 #![allow(clippy::async_yields_async)]
 
+use crate::constants::ROUTE_ID_DHT_KEY;
 use serde::{Serialize, Deserialize};
 use eyre::{Result, anyhow};
 use std::sync::Arc;
@@ -100,16 +101,15 @@ pub trait DHTEntity {
         Ok(())
     }
 
-     async fn store_route_id_in_dht(
+    async fn store_route_id_in_dht(
         &self,
-        subkey: u32,
         route_id_blob: Vec<u8>,
     ) -> Result<()> {
         let routing_context = &self.get_routing_context();
         let dht_record = self.get_dht_record();
         routing_context.set_dht_value(
                 dht_record.key().clone(),
-                subkey,
+                ROUTE_ID_DHT_KEY,
                 route_id_blob,
                 None,
             )
@@ -127,7 +127,7 @@ pub trait DHTEntity {
         
         // Get the stored route ID blob at subkey
         let stored_blob = routing_context
-            .get_dht_value(dht_record.key().clone(), subkey, false)
+            .get_dht_value(dht_record.key().clone(), ROUTE_ID_DHT_KEY, false)
             .await?
             .ok_or_else(|| anyhow!("Route ID blob not found in DHT"))?;
     

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,3 +6,4 @@ pub const UNABLE_TO_STORE_KEYPAIR: &str = "Unable to store keypair";
 pub const FAILED_TO_LOAD_KEYPAIR: &str = "Failed to load keypair";
 pub const KEYPAIR_NOT_FOUND: &str = "Keypair not found";
 pub const FAILED_TO_DESERIALIZE_KEYPAIR: &str = "Failed to deserialize keypair";
+pub const ROUTE_ID_DHT_KEY: u32 = 2;

--- a/src/group.rs
+++ b/src/group.rs
@@ -121,6 +121,26 @@ impl Group {
     }
     
 
+    // Send an AppMessage to the repo owner using the stored route ID blob
+    pub async fn send_message_to_owner(&self, veilid: &VeilidAPI, message: Vec<u8>) -> Result<()> {
+        let routing_context = &self.routing_context;
+    
+        // Retrieve the route ID blob from DHT
+        let route_id_blob = self.get_route_id_from_dht().await?;
+    
+        // Import the route using the blob via VeilidAPI
+        let route_id = veilid.import_remote_private_route(route_id_blob)?;
+    
+        // Send an AppMessage to the repo owner using the imported route ID
+        routing_context
+            .app_message(veilid_core::Target::PrivateRoute(route_id), message)
+            .await?;
+    
+        Ok(())
+    }
+
+}
+
 impl DHTEntity for Group {
     fn get_id(&self) -> CryptoKey {
         self.id().clone()

--- a/src/group.rs
+++ b/src/group.rs
@@ -2,7 +2,7 @@ use serde::{Serialize, Deserialize};
 use eyre::{Result, Error, anyhow};
 use std::sync::Arc;
 use veilid_core::{
-    CryptoKey, DHTRecordDescriptor, CryptoTyped, CryptoSystemVLD0, RoutingContext, SharedSecret, TypedKey, KeyPair, VeilidAPI
+    CryptoKey, DHTRecordDescriptor, CryptoTyped, CryptoSystemVLD0, RoutingContext, SharedSecret, TypedKey
 };
 
 use crate::common::DHTEntity;
@@ -60,83 +60,6 @@ impl Group {
         } else {
             Err(anyhow!("Repo not found"))
         }
-    }
-    
-    pub async fn store_route_id_in_dht(&self, route_id_blob: Vec<u8>) -> Result<()> {
-        let routing_context = &self.routing_context;
-    
-        println!("Attempting to open DHT record...");
-    
-        // Open the DHT record using the group's DHT record
-        let dht_record = routing_context
-            .open_dht_record(self.dht_record.key().clone(), self.owner_secret().map(|secret| KeyPair::new(self.owner_key(), secret)))
-            .await
-            .map_err(|e| {
-                println!("Failed to open DHT record: {}", e);
-                anyhow!("Failed to open DHT record: {}", e)
-            })?;
-    
-        println!("DHT record opened successfully.");
-    
-        // Set the stored route ID blob at subkey 2
-        routing_context
-            .set_dht_value(self.dht_record.key().clone(), 2u32, route_id_blob, self.owner_secret().map(|secret| KeyPair::new(self.owner_key(), secret)))
-            .await
-            .map_err(|e| {
-                println!("Failed to set value in DHT: {}", e);
-                anyhow!("Failed to set value in DHT: {}", e)
-            })?;
-    
-        println!("Value set successfully in DHT.");
-    
-        // Close the DHT record after setting the value
-        routing_context.close_dht_record(self.dht_record.key().clone()).await?;
-    
-        println!("DHT record closed successfully.");
-    
-        Ok(())
-    }
-    
-    pub async fn get_route_id_from_dht(&self) -> Result<Vec<u8>> {
-        let routing_context = &self.routing_context;
-        
-        println!("Reopening DHT record before reading...");
-        
-        // Ensure the DHT record is opened before reading
-        let dht_record = routing_context
-            .open_dht_record(self.dht_record.key().clone(), self.owner_secret().map(|secret| KeyPair::new(self.owner_key(), secret)))
-            .await
-            .map_err(|e| {
-                println!("Failed to reopen DHT record: {}", e);
-                anyhow!("Failed to reopen DHT record: {}", e)
-            })?;
-        
-        // Get the stored route ID blob at subkey 2
-        let stored_blob = routing_context
-            .get_dht_value(self.dht_record.key().clone(), 2u32, false)
-            .await?
-            .ok_or_else(|| anyhow!("Route ID blob not found in DHT"))?;
-    
-        Ok(stored_blob.data().to_vec())
-    }
-    
-
-    // Send an AppMessage to the repo owner using the stored route ID blob
-    pub async fn send_message_to_owner(&self, veilid: &VeilidAPI, message: Vec<u8>) -> Result<()> {
-        let routing_context = &self.routing_context;
-    
-        // Retrieve the route ID blob from DHT
-        let route_id_blob = self.get_route_id_from_dht().await?;
-    
-        // Import the route using the blob via VeilidAPI
-        let route_id = veilid.import_remote_private_route(route_id_blob)?;
-    
-        // Send an AppMessage to the repo owner using the imported route ID
-        routing_context
-            .app_message(veilid_core::Target::PrivateRoute(route_id), message)
-            .await?;
-    
-        Ok(())
     }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,17 @@ mod tests {
         let retrieved_name = loaded_repo.get_name().await.expect("Unable to get repo name after restart");
         assert_eq!(retrieved_name, repo_name);
 
+        // Generate a mock route_id_blob for testing
+        let route_id_blob = vec![1, 2, 3, 4, 5]; // Replace with real blob later
+    
+        // Test storing route_id_blob in DHT
+        loaded_group.store_route_id_in_dht(route_id_blob.clone()).await.expect("Failed to store route ID blob in DHT");
+    
+        // Verify that the DHT contains the stored route ID blob
+        let stored_blob = loaded_group.get_route_id_from_dht().await.expect("Failed to read route ID from DHT");
+
+        assert_eq!(stored_blob, route_id_blob);
+
         backend.stop().await.expect("Unable to stop");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,14 @@ use crate::constants::{GROUP_NOT_FOUND, UNABLE_TO_SET_GROUP_NAME, UNABLE_TO_GET_
 use crate::backend::Backend;
 use crate::common::{CommonKeypair, DHTEntity};
 use veilid_core::{
-    vld0_generate_keypair, TypedKey, CRYPTO_KIND_VLD0
+    vld0_generate_keypair, TypedKey, CRYPTO_KIND_VLD0, VeilidUpdate, VALID_CRYPTO_KINDS
 };
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use tokio::fs;
+    use tokio::sync::mpsc;    
     use tmpdir::TmpDir;
 
     #[tokio::test]
@@ -37,7 +38,7 @@ mod tests {
         backend.stop().await.expect("Unable to stop");
 
         backend.start().await.expect("Unable to restart");
-        let loaded_group = backend.get_group(TypedKey::new(CRYPTO_KIND_VLD0, group.id())).await.expect(GROUP_NOT_FOUND);
+        let mut loaded_group = backend.get_group(TypedKey::new(CRYPTO_KIND_VLD0, group.id())).await.expect(GROUP_NOT_FOUND);
 
         let protected_store = backend.get_protected_store().unwrap();
         let keypair_data = protected_store.load_user_secret(group.id().to_string())
@@ -55,8 +56,6 @@ mod tests {
         // Check that the secret and encryption keys match
         assert_eq!(retrieved_keypair.secret_key, group.get_secret_key());
         assert_eq!(retrieved_keypair.encryption_key, group.get_encryption_key());
-
-        let mut loaded_group = backend.get_group(TypedKey::new(CRYPTO_KIND_VLD0, group.id())).await.expect(GROUP_NOT_FOUND);
 
         // Check if we can get group name
         let group_name = loaded_group.get_name().await.expect(UNABLE_TO_GET_GROUP_NAME);
@@ -76,7 +75,7 @@ mod tests {
         assert_eq!(name, repo_name);
 
         // Add repo to group
-        loaded_group.add_repo(repo).await.expect("Unable to add repo to group");
+        loaded_group.add_repo(repo.clone()).await.expect("Unable to add repo to group");
 
         // List known repos
         let repos = loaded_group.list_repos().await;
@@ -89,16 +88,61 @@ mod tests {
         let retrieved_name = loaded_repo.get_name().await.expect("Unable to get repo name after restart");
         assert_eq!(retrieved_name, repo_name);
 
-        // Generate a mock route_id_blob for testing
-        let route_id_blob = vec![1, 2, 3, 4, 5]; // Replace with real blob later
-    
-        // Test storing route_id_blob in DHT
-        loaded_group.store_route_id_in_dht(route_id_blob.clone()).await.expect("Failed to store route ID blob in DHT");
-    
-        // Verify that the DHT contains the stored route ID blob
-        let stored_blob = loaded_group.get_route_id_from_dht().await.expect("Failed to read route ID from DHT");
+        // Get the update receiver from the backend
+        let update_rx = backend
+            .get_update_receiver()
+            .expect("Failed to get update receiver");
 
-        assert_eq!(stored_blob, route_id_blob);
+        // Set up a channel to receive AppMessage updates
+        let (message_tx, mut message_rx) = mpsc::channel(1);
+
+        // Spawn a task to listen for updates
+        tokio::spawn(async move {
+            let mut rx = update_rx.lock().await;
+            while let Some(update) = rx.recv().await {
+                if let VeilidUpdate::AppMessage(app_message) = update {
+                    // Optionally, filter by route_id or other criteria
+                    message_tx.send(app_message).await.unwrap();
+                }
+            }
+        });
+
+        // Get VeilidAPI instance from backend
+        let veilid_api = backend.get_veilid_api().expect("Failed to get VeilidAPI instance");
+
+        // Define the subkey
+        let subkey = 2u32;
+
+        // Create a new private route
+        let (route_id, route_id_blob) = veilid_api
+            .new_custom_private_route(
+                &VALID_CRYPTO_KINDS,
+                veilid_core::Stability::Reliable,
+                veilid_core::Sequencing::PreferOrdered,
+            )
+            .await
+            .expect("Failed to create route");
+
+        // Store the route_id_blob in DHT
+        loaded_repo
+            .store_route_id_in_dht(subkey, route_id_blob.clone())
+            .await
+            .expect("Failed to store route ID blob in DHT");
+
+        // Define the message to send
+        let message = b"Test Message to Repo Owner".to_vec();
+
+        // Send the message
+        loaded_repo
+            .send_message_to_owner(veilid_api, message.clone(), subkey)
+            .await
+            .expect("Failed to send message to repo owner");
+
+        // Receive the message
+        let received_app_message = message_rx.recv().await.expect("Failed to receive message");
+
+        // Verify the message
+        assert_eq!(received_app_message.message(), message.as_slice());
 
         backend.stop().await.expect("Unable to stop");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ pub mod backend;
 pub mod common;
 pub mod constants;
 
-use crate::constants::{GROUP_NOT_FOUND, UNABLE_TO_SET_GROUP_NAME, UNABLE_TO_GET_GROUP_NAME, TEST_GROUP_NAME, UNABLE_TO_STORE_KEYPAIR, FAILED_TO_LOAD_KEYPAIR, KEYPAIR_NOT_FOUND, FAILED_TO_DESERIALIZE_KEYPAIR};
+use crate::constants::{GROUP_NOT_FOUND, UNABLE_TO_SET_GROUP_NAME, UNABLE_TO_GET_GROUP_NAME, TEST_GROUP_NAME, UNABLE_TO_STORE_KEYPAIR, FAILED_TO_LOAD_KEYPAIR, KEYPAIR_NOT_FOUND, FAILED_TO_DESERIALIZE_KEYPAIR, ROUTE_ID_DHT_KEY};
 
 use crate::backend::Backend;
 use crate::common::{CommonKeypair, DHTEntity};
@@ -108,9 +108,6 @@ mod tests {
         // Get VeilidAPI instance from backend
         let veilid_api = backend.get_veilid_api().expect("Failed to get VeilidAPI instance");
 
-        // Define the subkey
-        let subkey = 2u32;
-
         // Create a new private route
         let (route_id, route_id_blob) = veilid_api
             .new_custom_private_route(
@@ -123,7 +120,7 @@ mod tests {
 
         // Store the route_id_blob in DHT
         loaded_repo
-            .store_route_id_in_dht(subkey, route_id_blob.clone())
+            .store_route_id_in_dht(route_id_blob.clone())
             .await
             .expect("Failed to store route ID blob in DHT");
 
@@ -132,7 +129,7 @@ mod tests {
 
         // Send the message
         loaded_repo
-            .send_message_to_owner(veilid_api, message.clone(), subkey)
+            .send_message_to_owner(veilid_api, message.clone(), ROUTE_ID_DHT_KEY)
             .await
             .expect("Failed to send message to repo owner");
 


### PR DESCRIPTION
- Added DHT schema support for storing route blob IDs with multiple subkeys.
- Integrated group route ID management to handle messaging through VeilidAPI.
- Implemented functionality for creating and storing custom private routes in the DHT.
- Enhanced test coverage to verify route creation, message sending, and receiving via AppMessage updates.