### PR TITLE
Set test-threads to 1

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Run tests
         env:
           RUST_MIN_STACK: 8388608
-        run: cargo test --verbose
+        run: cargo test --verbose -- --test-threads=1 --nocapture


### PR DESCRIPTION
This sets the test-threads to 1 so that test do not run in parallel until refactor a bit to be able to load multiple veilid instances 
