### PR TITLE
Inner backend, refactor repo creation

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -61,14 +61,16 @@ impl BackendInner {
     }
 
     fn veilid(&self) -> Result<VeilidAPI> {
-        Ok(self.veilid_api
+        Ok(self
+            .veilid_api
             .as_ref()
             .ok_or_else(|| anyhow!("Veilid API not initialized"))?
             .clone())
     }
 
     fn iroh_blobs(&self) -> Result<VeilidIrohBlobs> {
-        Ok(self.iroh_blobs
+        Ok(self
+            .iroh_blobs
             .as_ref()
             .ok_or_else(|| anyhow!("Veilid Iroh Blobs API not initialized"))?
             .clone())

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -61,17 +61,17 @@ impl BackendInner {
     }
 
     fn veilid(&self) -> Result<VeilidAPI> {
-        self.veilid_api
+        Ok(self.veilid_api
             .as_ref()
-            .ok_or_else(|| anyhow!("Veilid API not initialized"))
-            .map(|store| store.clone())
+            .ok_or_else(|| anyhow!("Veilid API not initialized"))?
+            .clone())
     }
 
     fn iroh_blobs(&self) -> Result<VeilidIrohBlobs> {
-        self.iroh_blobs
+        Ok(self.iroh_blobs
             .as_ref()
-            .ok_or_else(|| anyhow!("Veilid Iroh Blobs API not initialized"))
-            .map(|iroh_blobs| iroh_blobs.clone())
+            .ok_or_else(|| anyhow!("Veilid Iroh Blobs API not initialized"))?
+            .clone())
     }
 
     fn get_protected_store(&self) -> Result<ProtectedStore> {
@@ -127,7 +127,7 @@ impl Backend {
             tokio::spawn(async move {
                 let inner = inner.lock().await;
 
-                for group in inner.groups.clone().into_values().into_iter() {
+                for group in inner.groups.clone().into_values() {
                     if let Some(repo) = group.get_own_repo() {
                         if let Err(err) = repo.update_route_on_dht().await {
                             eprintln!(
@@ -196,7 +196,7 @@ impl Backend {
             tokio::spawn(async move {
                 let inner = inner.lock().await;
 
-                for group in inner.groups.clone().into_values().into_iter() {
+                for group in inner.groups.clone().into_values() {
                     if let Some(repo) = group.get_own_repo() {
                         if let Err(err) = repo.update_route_on_dht().await {
                             eprintln!(
@@ -338,7 +338,7 @@ impl Backend {
 
     pub async fn get_group(&self, record_key: &CryptoKey) -> Result<Box<Group>> {
         let mut inner = self.inner.lock().await;
-        if let Some(group) = inner.groups.get(&record_key) {
+        if let Some(group) = inner.groups.get(record_key) {
             return Ok(group.clone());
         }
         let iroh_blobs = inner.iroh_blobs()?;
@@ -348,7 +348,7 @@ impl Backend {
         let protected_store = veilid.protected_store().unwrap();
 
         // Load the keypair associated with the record_key from the protected store
-        let retrieved_keypair = CommonKeypair::load_keypair(&protected_store, &record_key)
+        let retrieved_keypair = CommonKeypair::load_keypair(&protected_store, record_key)
             .await
             .map_err(|_| anyhow!("Failed to load keypair"))?;
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,7 @@
 use crate::constants::ROUTE_ID_DHT_KEY;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
-use std::{path::PathBuf, sync::Arc};
+use std::{path::PathBuf, path::Path, sync::Arc};
 use tokio::sync::broadcast::{self, Receiver};
 use veilid_core::{
     CryptoKey, CryptoSystem, CryptoSystemVLD0, CryptoTyped, DHTRecordDescriptor, KeyPair, Nonce,
@@ -33,7 +33,7 @@ pub async fn make_route(veilid: &VeilidAPI) -> Result<(RouteId, Vec<u8>)> {
     Err(anyhow!("Unable to create route, reached max retries"))
 }
 
-pub async fn init_veilid(base_dir: &PathBuf) -> Result<(VeilidAPI, Receiver<VeilidUpdate>)> {
+pub async fn init_veilid(base_dir: &Path) -> Result<(VeilidAPI, Receiver<VeilidUpdate>)> {
     let config_inner = config_for_dir(base_dir.to_path_buf());
 
     let (tx, mut rx) = broadcast::channel(32);

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,7 @@
 use crate::constants::ROUTE_ID_DHT_KEY;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
-use std::{path::PathBuf, path::Path, sync::Arc};
+use std::{path::Path, path::PathBuf, sync::Arc};
 use tokio::sync::broadcast::{self, Receiver};
 use veilid_core::{
     CryptoKey, CryptoSystem, CryptoSystemVLD0, CryptoTyped, DHTRecordDescriptor, KeyPair, Nonce,

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,11 +4,12 @@
 use crate::constants::ROUTE_ID_DHT_KEY;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
+use tokio::sync::broadcast::{self, Receiver};
 use veilid_core::{
     CryptoKey, CryptoSystem, CryptoSystemVLD0, CryptoTyped, DHTRecordDescriptor, KeyPair, Nonce,
-    ProtectedStore, RouteId, RoutingContext, Sequencing, SharedSecret, Stability, VeilidAPI,
-    CRYPTO_KIND_VLD0, VALID_CRYPTO_KINDS,
+    ProtectedStore, RouteId, RoutingContext, Sequencing, SharedSecret, Stability, UpdateCallback,
+    VeilidAPI, VeilidConfigInner, VeilidUpdate, CRYPTO_KIND_VLD0, VALID_CRYPTO_KINDS,
 };
 
 pub async fn make_route(veilid: &VeilidAPI) -> Result<(RouteId, Vec<u8>)> {
@@ -30,6 +31,67 @@ pub async fn make_route(veilid: &VeilidAPI) -> Result<(RouteId, Vec<u8>)> {
         }
     }
     Err(anyhow!("Unable to create route, reached max retries"))
+}
+
+pub async fn init_veilid(base_dir: &PathBuf) -> Result<(VeilidAPI, Receiver<VeilidUpdate>)> {
+    let config_inner = config_for_dir(base_dir.to_path_buf());
+
+    let (tx, mut rx) = broadcast::channel(32);
+
+    let update_callback: UpdateCallback = Arc::new(move |update| {
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            if tx.send(update).is_err() {
+                // TODO:
+                //println!("receiver dropped");
+            }
+        });
+    });
+
+    // println!("Init veilid");
+    let veilid = veilid_core::api_startup_config(update_callback, config_inner).await?;
+
+    //println!("Attach veilid");
+
+    veilid.attach().await?;
+
+    //println!("Wait for veilid network");
+
+    while let Ok(update) = rx.recv().await {
+        if let VeilidUpdate::Attachment(attachment_state) = update {
+            if attachment_state.public_internet_ready && attachment_state.state.is_attached() {
+                println!("Public internet ready!");
+                break;
+            }
+        }
+    }
+
+    Ok((veilid, rx))
+}
+
+pub fn config_for_dir(base_dir: PathBuf) -> VeilidConfigInner {
+    return VeilidConfigInner {
+        program_name: "save-dweb-backend".to_string(),
+        namespace: "openarchive".into(),
+        protected_store: veilid_core::VeilidConfigProtectedStore {
+            // avoid prompting for password, don't do this in production
+            always_use_insecure_storage: true,
+            directory: base_dir
+                .join("protected_store")
+                .to_string_lossy()
+                .to_string(),
+            ..Default::default()
+        },
+        table_store: veilid_core::VeilidConfigTableStore {
+            directory: base_dir.join("table_store").to_string_lossy().to_string(),
+            ..Default::default()
+        },
+        block_store: veilid_core::VeilidConfigBlockStore {
+            directory: base_dir.join("block_store").to_string_lossy().to_string(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
 }
 
 #[derive(Serialize, Deserialize)]
@@ -66,7 +128,7 @@ impl CommonKeypair {
 pub trait DHTEntity {
     fn get_id(&self) -> CryptoKey;
     fn get_encryption_key(&self) -> SharedSecret;
-    fn get_routing_context(&self) -> Arc<RoutingContext>;
+    fn get_routing_context(&self) -> RoutingContext;
     fn get_crypto_system(&self) -> CryptoSystemVLD0;
     fn get_dht_record(&self) -> DHTRecordDescriptor;
     fn get_secret_key(&self) -> Option<CryptoKey>;

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,20 +1,24 @@
-use crate::common::DHTEntity;
+use crate::common::CommonKeypair;
 use crate::repo::Repo;
+use crate::{common::DHTEntity, repo};
 use anyhow::{anyhow, Error, Result};
 use bytes::Bytes;
 use hex::ToHex;
+use iroh::net::key::SecretKey;
 use iroh_blobs::Hash;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use url::Url;
 use veilid_core::{
-    CryptoKey, CryptoSystemVLD0, CryptoTyped, DHTRecordDescriptor, ProtectedStore, RoutingContext,
-    SharedSecret, TypedKey,
+    CryptoKey, CryptoSystemVLD0, CryptoTyped, DHTRecordDescriptor, DHTReportScope, DHTSchema,
+    KeyPair, ProtectedStore, RoutingContext, SharedSecret, TypedKey, ValueSubkeyRangeSet,
+    VeilidAPI, CRYPTO_KEY_LENGTH, CRYPTO_KIND_VLD0,
 };
 use veilid_iroh_blobs::iroh::VeilidIrohBlobs;
 
@@ -29,9 +33,9 @@ pub struct Group {
     pub dht_record: DHTRecordDescriptor,
     pub encryption_key: SharedSecret,
     pub routing_context: RoutingContext,
-    pub crypto_system: CryptoSystemVLD0,
-    pub repos: Vec<Repo>,
-    pub iroh_blobs: Option<VeilidIrohBlobs>,
+    pub repos: HashMap<CryptoKey, Box<Repo>>,
+    pub veilid: VeilidAPI,
+    pub iroh_blobs: VeilidIrohBlobs,
 }
 
 impl Group {
@@ -39,15 +43,15 @@ impl Group {
         dht_record: DHTRecordDescriptor,
         encryption_key: SharedSecret,
         routing_context: RoutingContext,
-        crypto_system: CryptoSystemVLD0,
-        iroh_blobs: Option<VeilidIrohBlobs>,
+        veilid: VeilidAPI,
+        iroh_blobs: VeilidIrohBlobs,
     ) -> Self {
         Self {
             dht_record,
             encryption_key,
             routing_context,
-            crypto_system,
-            repos: Vec::new(),
+            repos: HashMap::new(),
+            veilid,
             iroh_blobs,
         }
     }
@@ -64,29 +68,37 @@ impl Group {
         self.dht_record.owner_secret().cloned()
     }
 
-    pub fn add_repo(&mut self, repo: Repo) -> Result<()> {
-        self.repos.push(repo);
-        Ok(())
+    fn add_repo(&mut self, repo: Repo) -> Result<&Box<Repo>> {
+        let id = repo.id();
+        let repo = Box::new(repo);
+        self.repos.insert(id, repo);
+        Ok(self.repos.get(&id).unwrap())
+    }
+
+    pub fn get_repo(&self, id: &CryptoKey) -> Result<&Box<Repo>> {
+        self.repos.get(id).ok_or_else(|| anyhow!("Repo not loaded"))
+    }
+
+    pub fn has_repo(&self, id: &CryptoKey) -> bool {
+        self.repos.contains_key(id)
     }
 
     pub fn list_repos(&self) -> Vec<CryptoKey> {
-        self.repos.iter().map(|repo| repo.get_id()).collect()
+        self.repos.iter().map(|(_, repo)| repo.get_id()).collect()
     }
 
-    pub fn get_own_repo(&self) -> Option<&Repo> {
-        self.repos.iter().find(|repo| repo.can_write())
+    pub fn get_own_repo(&self) -> Option<&Box<Repo>> {
+        self.repos.values().find(|repo| repo.can_write())
     }
 
-    pub fn list_peer_repos(&self) -> Vec<&Repo> {
-        self.repos.iter().filter(|repo| !repo.can_write()).collect()
+    pub fn list_peer_repos(&self) -> Vec<&Box<Repo>> {
+        self.repos
+            .values()
+            .filter(|repo| !repo.can_write())
+            .collect()
     }
 
     pub async fn download_hash_from_peers(&self, hash: &Hash) -> Result<()> {
-        let iroh_blobs = match self.iroh_blobs.as_ref() {
-            Some(iroh_blobs) => iroh_blobs,
-            None => return Err(anyhow!("Iroh not initialized")),
-        };
-
         // Ask peers to download in random order
         let mut rng = thread_rng();
         let mut repos = self.list_peer_repos();
@@ -95,7 +107,12 @@ impl Group {
         for repo in repos.iter() {
             if let Ok(route_id_blob) = repo.get_route_id_blob().await {
                 // It's faster to try and fail, than to ask then try
-                if (iroh_blobs.download_file_from(route_id_blob, hash).await).is_ok() {
+                if (self
+                    .iroh_blobs
+                    .download_file_from(route_id_blob, hash)
+                    .await)
+                    .is_ok()
+                {
                     return Ok(());
                 }
             }
@@ -105,15 +122,10 @@ impl Group {
     }
 
     pub async fn peers_have_hash(&self, hash: &Hash) -> Result<bool> {
-        let iroh_blobs = match self.iroh_blobs.as_ref() {
-            Some(iroh_blobs) => iroh_blobs,
-            None => return Err(anyhow!("Iroh not initialized")),
-        };
-
         for repo in self.list_peer_repos().iter() {
             println!("Askinng {} from {}", hash, repo.id());
             if let Ok(route_id_blob) = repo.get_route_id_blob().await {
-                if let Ok(has) = iroh_blobs.ask_hash(route_id_blob, *hash).await {
+                if let Ok(has) = self.iroh_blobs.ask_hash(route_id_blob, *hash).await {
                     if has {
                         return Ok(true);
                     }
@@ -125,12 +137,7 @@ impl Group {
     }
 
     pub async fn has_hash(&self, hash: &Hash) -> Result<bool> {
-        let iroh_blobs = match self.iroh_blobs.as_ref() {
-            Some(iroh_blobs) => iroh_blobs,
-            None => return Err(anyhow!("Iroh not initialized")),
-        };
-
-        let has = iroh_blobs.has_hash(hash).await;
+        let has = self.iroh_blobs.has_hash(hash).await;
 
         Ok(has)
     }
@@ -139,22 +146,17 @@ impl Group {
         &self,
         hash: &Hash,
     ) -> Result<mpsc::Receiver<std::io::Result<Bytes>>> {
-        let iroh_blobs = match self.iroh_blobs.as_ref() {
-            Some(iroh_blobs) => iroh_blobs,
-            None => return Err(anyhow!("Iroh not initialized")),
-        };
-
         if self.has_hash(hash).await? {
             self.download_hash_from_peers(hash).await?
         }
 
-        let receiver = iroh_blobs.read_file(*hash).await.unwrap();
+        let receiver = self.iroh_blobs.read_file(*hash).await.unwrap();
 
         Ok(receiver)
     }
 
     pub async fn get_repo_name(&self, repo_key: CryptoKey) -> Result<String> {
-        if let Some(repo) = self.repos.iter().find(|repo| repo.get_id() == repo_key) {
+        if let Some(repo) = self.repos.get(&repo_key) {
             repo.get_name().await
         } else {
             Err(anyhow!("Repo not found"))
@@ -181,6 +183,213 @@ impl Group {
 
         url.to_string()
     }
+
+    async fn dht_repo_count(&self) -> Result<usize> {
+        let dht_record = &self.dht_record;
+        let range = ValueSubkeyRangeSet::full();
+        let scope = DHTReportScope::UpdateGet;
+
+        let report = self
+            .routing_context
+            .inspect_dht_record(dht_record.key().clone(), range, scope)
+            .await?;
+
+        let count = report.network_seqs().len();
+
+        Ok(count)
+    }
+
+    pub async fn advertise_own_repo(&self) -> Result<()> {
+        let repo = self
+            .get_own_repo()
+            .ok_or_else(|| anyhow!("No own repo found for group"))?;
+
+        let repo_key = repo.id().to_vec();
+
+        let count = self.dht_repo_count().await?;
+
+        self.routing_context
+            .set_dht_value(
+                self.dht_record.key().clone(),
+                count.try_into()?,
+                repo_key,
+                None,
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn load_repo_from_network(&mut self, repo_id: TypedKey) -> Result<&Box<Repo>> {
+        // TODO: Load keypair from DHT
+        //        let protected_store = self.protected_store().unwrap();
+        // Load keypair using the repo ID
+        // let retrieved_keypair = CommonKeypair::load_keypair(&protected_store, &repo_id.value)
+        //    .await
+        //     .map_err(|_| anyhow!("Failed to load keypair for repo_id: {:?}", repo_id))?;
+        // Some(KeyPair::new(
+        //             owner_key.clone(),
+        //             retrieved_keypair.secret_key.clone().unwrap(),
+        //         ))
+        let keypair = None;
+
+        let dht_record = self
+            .routing_context
+            .open_dht_record(repo_id.clone(), keypair)
+            .await?;
+
+        let repo = Repo {
+            dht_record,
+            encryption_key: self.encryption_key.clone(),
+            secret_key: None,
+            routing_context: self.routing_context.clone(),
+            crypto_system: self.get_crypto_system(),
+            iroh_blobs: self.iroh_blobs.clone(),
+        };
+
+        self.add_repo(repo)
+    }
+
+    async fn load_repo_from_dht(&mut self, subkey: u32) -> Result<CryptoTyped<CryptoKey>> {
+        let repo_id_raw = self
+            .routing_context
+            .get_dht_value(self.dht_record.key().clone(), subkey, false)
+            .await?
+            .ok_or_else(|| anyhow!("Unable to load repo ID from DHT"))?;
+
+        let mut repo_id_buffer: [u8; CRYPTO_KEY_LENGTH] = [0; CRYPTO_KEY_LENGTH];
+
+        repo_id_buffer.copy_from_slice(repo_id_raw.data());
+
+        let repo_id = TypedKey::new(CRYPTO_KIND_VLD0, CryptoKey::from(repo_id_buffer));
+
+        self.load_repo_from_network(repo_id).await?;
+
+        Ok(repo_id)
+    }
+
+    pub async fn load_repos_from_dht(&mut self) -> Result<()> {
+        let count = self.dht_repo_count().await?;
+
+        let mut i = 1;
+        while i < count {
+            self.load_repo_from_dht(i.try_into()?).await?;
+            i += 1;
+        }
+
+        Ok(())
+    }
+
+    pub async fn load_repo_from_disk(&mut self) -> Result<&Box<Repo>> {
+        let protected_store = self.veilid.protected_store().unwrap();
+
+        let mut group_repo_key = self.id().to_string();
+        group_repo_key.push_str("-repo");
+
+        let key_bytes = protected_store
+            .load_user_secret(group_repo_key)
+            .await
+            .map_err(|err| anyhow!("Unable to load repo from disk"))?
+            .ok_or_else(|| anyhow!("No repo exists on disk for this group"))?;
+
+        let mut id_bytes: [u8; CRYPTO_KEY_LENGTH] = [0; CRYPTO_KEY_LENGTH];
+        id_bytes.copy_from_slice(&key_bytes);
+        let repo_id = TypedKey::new(CRYPTO_KIND_VLD0, CryptoKey::from(id_bytes));
+
+        let keypair = self.get_repo_keypair(repo_id).await?;
+
+        let dht_record = self
+            .routing_context
+            .open_dht_record(
+                repo_id.clone(),
+                Some(KeyPair::new(
+                    keypair.public_key.clone(),
+                    keypair.secret_key.clone().unwrap(),
+                )),
+            )
+            .await?;
+
+        let secret_key = keypair
+            .secret_key
+            .map(|key| TypedKey::new(CRYPTO_KIND_VLD0, key));
+
+        let repo = Repo {
+            dht_record,
+            encryption_key: self.encryption_key.clone(),
+            secret_key: secret_key,
+            routing_context: self.routing_context.clone(),
+            crypto_system: self.get_crypto_system(),
+            iroh_blobs: self.iroh_blobs.clone(),
+        };
+
+        self.add_repo(repo)
+    }
+
+    pub async fn create_repo(&mut self) -> Result<&Box<Repo>> {
+        if self.get_own_repo().is_some() {
+            return Err(anyhow!("Own repo already created for group"));
+        }
+
+        // Create a new DHT record for the repo
+        let schema = DHTSchema::dflt(3)?;
+        let kind = Some(CRYPTO_KIND_VLD0);
+        let repo_dht_record = self.routing_context.create_dht_record(schema, kind).await?;
+
+        // Identify the repo with the DHT record's key
+        let repo_id = repo_dht_record.key().clone();
+
+        // Use the group's encryption key for the repo
+        let encryption_key = self.get_encryption_key().clone();
+
+        // Wrap the secret key in CryptoTyped for storage
+        let secret_key_typed =
+            CryptoTyped::new(CRYPTO_KIND_VLD0, self.get_secret_key().unwrap().clone());
+
+        let repo = Repo::new(
+            repo_dht_record.clone(),
+            encryption_key,
+            Some(secret_key_typed),
+            self.routing_context.clone(),
+            self.get_crypto_system(),
+            self.iroh_blobs.clone(),
+        );
+
+        // This should happen every time the route ID changes
+        repo.update_route_on_dht().await?;
+
+        let protected_store = self.veilid.protected_store().unwrap();
+
+        let keypair = CommonKeypair {
+            id: repo.id(),
+            public_key: repo_dht_record.owner().clone(),
+            secret_key: self.get_secret_key(),
+            encryption_key: encryption_key.clone(),
+        };
+
+        keypair
+            .store_keypair(&protected_store)
+            .await
+            .map_err(|e| anyhow!(e))?;
+
+        let mut group_repo_key = self.id().to_string();
+        group_repo_key.push_str("-repo");
+        let key_bytes = *repo.id();
+        protected_store
+            .save_user_secret(group_repo_key, key_bytes.as_slice())
+            .await
+            .map_err(|e| anyhow!("Unable to store repo id for group: {}", e))?;
+
+        Ok(self.add_repo(repo)?)
+    }
+
+    async fn get_repo_keypair(&self, repo_id: TypedKey) -> Result<CommonKeypair> {
+        let protected_store = self.veilid.protected_store()?;
+
+        // Load keypair using the repo ID
+        CommonKeypair::load_keypair(&protected_store, &repo_id.value)
+            .await
+            .map_err(|_| anyhow!("Failed to load keypair for repo_id: {:?}", repo_id))
+    }
 }
 
 impl DHTEntity for Group {
@@ -197,7 +406,8 @@ impl DHTEntity for Group {
     }
 
     fn get_crypto_system(&self) -> CryptoSystemVLD0 {
-        self.crypto_system.clone()
+        // TODO handle the error?
+        CryptoSystemVLD0::new(self.veilid.crypto().unwrap())
     }
 
     fn get_dht_record(&self) -> DHTRecordDescriptor {

--- a/src/group.rs
+++ b/src/group.rs
@@ -28,7 +28,7 @@ pub const URL_SECRET_KEY: &str = "sk";
 pub struct Group {
     pub dht_record: DHTRecordDescriptor,
     pub encryption_key: SharedSecret,
-    pub routing_context: Arc<RoutingContext>,
+    pub routing_context: RoutingContext,
     pub crypto_system: CryptoSystemVLD0,
     pub repos: Vec<Repo>,
     pub iroh_blobs: Option<VeilidIrohBlobs>,
@@ -38,7 +38,7 @@ impl Group {
     pub fn new(
         dht_record: DHTRecordDescriptor,
         encryption_key: SharedSecret,
-        routing_context: Arc<RoutingContext>,
+        routing_context: RoutingContext,
         crypto_system: CryptoSystemVLD0,
         iroh_blobs: Option<VeilidIrohBlobs>,
     ) -> Self {
@@ -111,6 +111,7 @@ impl Group {
         };
 
         for repo in self.list_peer_repos().iter() {
+            println!("Askinng {} from {}", hash, repo.id());
             if let Ok(route_id_blob) = repo.get_route_id_blob().await {
                 if let Ok(has) = iroh_blobs.ask_hash(route_id_blob, *hash).await {
                     if has {
@@ -191,7 +192,7 @@ impl DHTEntity for Group {
         self.encryption_key.clone()
     }
 
-    fn get_routing_context(&self) -> Arc<RoutingContext> {
+    fn get_routing_context(&self) -> RoutingContext {
         self.routing_context.clone()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,6 +381,8 @@ mod tests {
             .create_group()
             .await
             .expect("Failed to create group");
+        let group_id = group.id();
+
         let repo = group.create_repo().await.expect("Unable to create repo");
 
         let repo_name = "Test Repo";
@@ -394,19 +396,20 @@ mod tests {
         let repo_id = repo.id();
         println!("lib: Repo created with id: {:?}", repo_id);
 
+        drop(group);
+
         backend.stop().await.expect("Unable to stop backend");
 
         backend.start().await.expect("Unable to restart backend");
 
         println!(
             "Backend restarted, attempting to load group with ID: {:?}",
-            group.id()
+            group_id
         );
 
-        let mut loaded_group = backend.get_group(&group.id()).await.expect(GROUP_NOT_FOUND);
+        let mut loaded_group = backend.get_group(&group_id).await.expect(GROUP_NOT_FOUND);
         let loaded_repo = loaded_group
-            .load_repo_from_disk()
-            .await
+            .get_own_repo()
             .expect("Repo not found after restart");
 
         let retrieved_name = loaded_repo
@@ -628,6 +631,7 @@ mod tests {
         assert_eq!(keys.id, group.id());
         backend.stop().await.expect("Unable to stop");
     }
+
     #[tokio::test]
     #[serial]
     async fn list_repos_test() -> Result<()> {
@@ -1036,22 +1040,26 @@ mod tests {
     #[serial]
     async fn test_repo_collection_management() -> Result<()> {
         // Setup a temporary directory and initialize the backend
-        let path = TmpDir::new("test_repo_collection_management").await.unwrap();
+        let path = TmpDir::new("test_repo_collection_management")
+            .await
+            .unwrap();
         let port = 8080;
-        fs::create_dir_all(path.as_ref()).await.expect("Failed to create base directory");
+        fs::create_dir_all(path.as_ref())
+            .await
+            .expect("Failed to create base directory");
 
         // Initialize the backend
         let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         // Step 1: Create a group
-        let mut group = backend.create_group().await.expect("Failed to create group");
+        let mut group = backend
+            .create_group()
+            .await
+            .expect("Failed to create group");
 
         // Step 2: Create a repo and verify it can write (i.e., has a secret key)
-        let mut repo = group
-            .create_repo()
-            .await
-            .expect("Failed to create repo");
+        let mut repo = group.create_repo().await.expect("Failed to create repo");
 
         assert!(repo.can_write(), "Repo should have write access");
 
@@ -1062,39 +1070,63 @@ mod tests {
             .await
             .expect("Unable to set repo name");
 
-         // Step 5: Upload a file, which implicitly creates the collection
+        // Step 5: Upload a file, which implicitly creates the collection
         let file_name = "example.txt";
         let file_content = b"Test content for file upload";
 
         // Upload the file (this will automatically create or get the collection)
         let file_hash = repo.upload(file_name, file_content.to_vec()).await?;
-        assert!(!file_hash.as_bytes().is_empty(), "File hash should not be empty after upload");
-       
+        assert!(
+            !file_hash.as_bytes().is_empty(),
+            "File hash should not be empty after upload"
+        );
+
         // Step 6: Use iroh_blobs set_file to update the collection with the uploaded file
         let blobs_future = backend.get_iroh_blobs().await;
         let iroh_blobs = blobs_future.as_ref().expect("iroh_blobs not initialized");
         let collection_name = repo.get_name().await.expect("Failed to get repo name");
-        let updated_collection_hash = repo.set_file_and_update_dht(&collection_name, file_name, &file_hash).await?;
-        assert!(!updated_collection_hash.as_bytes().is_empty(), "Updated collection hash should not be empty after adding file");
+        let updated_collection_hash = repo
+            .set_file_and_update_dht(&collection_name, file_name, &file_hash)
+            .await?;
+        assert!(
+            !updated_collection_hash.as_bytes().is_empty(),
+            "Updated collection hash should not be empty after adding file"
+        );
 
         // Step 7: Verify the file is listed in the collection
         let file_list = repo.list_files().await?;
-        assert_eq!(file_list.len(), 1, "There should be one file in the collection");
-        assert_eq!(file_list[0], file_name, "The listed file should match the uploaded file");
+        assert_eq!(
+            file_list.len(),
+            1,
+            "There should be one file in the collection"
+        );
+        assert_eq!(
+            file_list[0], file_name,
+            "The listed file should match the uploaded file"
+        );
 
         // Step 8: Retrieve the file hash from the collection and verify it matches the uploaded hash
         let retrieved_file_hash = repo.get_file_hash(file_name).await?;
-        assert_eq!(file_hash, retrieved_file_hash, "The retrieved file hash should match the uploaded file hash");
+        assert_eq!(
+            file_hash, retrieved_file_hash,
+            "The retrieved file hash should match the uploaded file hash"
+        );
 
         // Step 9: Delete the file from the collection
         let collection_hash_after_deletion = repo.delete_file(file_name).await?;
-        assert!(!collection_hash_after_deletion.as_bytes().is_empty(), "Collection hash should not be empty after file deletion");
+        assert!(
+            !collection_hash_after_deletion.as_bytes().is_empty(),
+            "Collection hash should not be empty after file deletion"
+        );
 
         // Step 10: Verify the file is no longer listed in the collection
         let file_list_after_deletion = repo.list_files().await?;
-        assert!(file_list_after_deletion.is_empty(), "The file list should be empty after deleting the file");
+        assert!(
+            file_list_after_deletion.is_empty(),
+            "The file list should be empty after deleting the file"
+        );
 
-        // Final Step -> Clean up 
+        // Final Step -> Clean up
         backend.stop().await.expect("Unable to stop backend");
         Ok(())
     }
@@ -1103,37 +1135,64 @@ mod tests {
     #[serial]
     async fn test_collection_hash_consistency() -> Result<()> {
         // Setup temporary directory and initialize the backend
-        let path = TmpDir::new("test_backend_collection_hash_consistency").await.unwrap();
+        let path = TmpDir::new("test_backend_collection_hash_consistency")
+            .await
+            .unwrap();
         let port = 8080;
-        fs::create_dir_all(path.as_ref()).await.expect("Failed to create base directory");
+        fs::create_dir_all(path.as_ref())
+            .await
+            .expect("Failed to create base directory");
 
         let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         // Step 1: Create a group and a collection
-        let group = backend.create_group().await.expect("Unable to create group");
+        let group = backend
+            .create_group()
+            .await
+            .expect("Unable to create group");
         let collection_name = "hash_consistency_collection".to_string();
         let blobs_future = backend.get_iroh_blobs().await;
         let iroh_blobs = blobs_future.as_ref().expect("iroh_blobs not initialized");
 
         // Step 2: Create collection and get initial hash
-        let initial_collection_hash = iroh_blobs.create_collection(&collection_name).await.expect("Failed to create collection");
-        
+        let initial_collection_hash = iroh_blobs
+            .create_collection(&collection_name)
+            .await
+            .expect("Failed to create collection");
+
         // Step 3: Upload a file to the collection
         let file_path = path.as_ref().join("file1.txt");
         let file_content = b"Content of file 1";
-        fs::write(&file_path, file_content).await.expect("Failed to write file 1");
+        fs::write(&file_path, file_content)
+            .await
+            .expect("Failed to write file 1");
 
-        let file_hash = iroh_blobs.upload_from_path(file_path.clone()).await.expect("Failed to upload file 1");
-        let updated_collection_hash = iroh_blobs.set_file(&collection_name, "file1.txt", &file_hash).await.expect("Failed to set file in collection");
+        let file_hash = iroh_blobs
+            .upload_from_path(file_path.clone())
+            .await
+            .expect("Failed to upload file 1");
+        let updated_collection_hash = iroh_blobs
+            .set_file(&collection_name, "file1.txt", &file_hash)
+            .await
+            .expect("Failed to set file in collection");
 
         // Verify that the collection hash changed after adding a file
-        assert_ne!(initial_collection_hash, updated_collection_hash, "The collection hash should change after a file is added");
+        assert_ne!(
+            initial_collection_hash, updated_collection_hash,
+            "The collection hash should change after a file is added"
+        );
 
         // Step 4: Remove the file and verify the hash changes again
-        let final_collection_hash = iroh_blobs.delete_file(&collection_name, "file1.txt").await.expect("Failed to delete file from collection");
+        let final_collection_hash = iroh_blobs
+            .delete_file(&collection_name, "file1.txt")
+            .await
+            .expect("Failed to delete file from collection");
 
-        assert_ne!(updated_collection_hash, final_collection_hash, "The collection hash should change after a file is removed");
+        assert_ne!(
+            updated_collection_hash, final_collection_hash,
+            "The collection hash should change after a file is removed"
+        );
 
         // Clean up
         backend.stop().await.expect("Unable to stop backend");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ mod tests {
             .expect("Failed to create base directory");
 
         // Initialize the backend
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         // Create a group and a repo
@@ -115,7 +115,7 @@ mod tests {
             .await
             .expect("Failed to create base directory");
 
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         let group = backend
@@ -144,7 +144,7 @@ mod tests {
             .await
             .expect("Failed to create base directory");
 
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         let group = backend
@@ -197,7 +197,7 @@ mod tests {
             .await
             .expect("Failed to create base directory");
 
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         // Step 1: Create a group before creating a repo
@@ -261,7 +261,7 @@ mod tests {
                 .await
                 .expect("Failed to create base directory");
 
-            let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+            let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
             backend.start().await.expect("Unable to start");
 
             // Add delay to ensure backend initialization
@@ -355,7 +355,7 @@ mod tests {
             .await
             .expect("Failed to create base directory");
 
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         let group = backend
@@ -394,7 +394,7 @@ mod tests {
             .await
             .expect("Failed to create base directory");
 
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start backend");
 
         let mut group = backend
@@ -467,7 +467,7 @@ mod tests {
             .expect("Failed to create base directory");
 
         // Initialize the backend
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         // Create a group
@@ -549,7 +549,7 @@ mod tests {
             .expect("Failed to create base directory");
 
         // Initialize the backend
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         // Create a group
@@ -633,7 +633,7 @@ mod tests {
             .await
             .expect("Failed to create base directory");
 
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
 
         backend.start().await.expect("Unable to start");
         let group = backend
@@ -663,7 +663,7 @@ mod tests {
             .await
             .expect("Failed to create base directory");
 
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         // Create a group and two repos
@@ -697,7 +697,7 @@ mod tests {
             .await
             .expect("Failed to create base directory");
 
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         // Create a group and two repos, one writable
@@ -737,7 +737,7 @@ mod tests {
             .await
             .expect("Failed to create base directory");
 
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         // Create a group and a peer repo
@@ -811,7 +811,7 @@ mod tests {
             .await
             .expect("Failed to create base directory");
 
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         // Create a group and a peer repo
@@ -819,6 +819,7 @@ mod tests {
             .create_group()
             .await
             .expect("Unable to create group");
+
         let mut peer_repo = backend.create_repo(&group.id()).await?;
 
         // Add the peer repo to the group
@@ -861,12 +862,12 @@ mod tests {
             !new_file_collection_hash.as_bytes().is_empty(),
             "New collection hash after uploading a file should not be empty"
         );
-
+        println!("Asking peers");
         // Add delay to allow peers to propagate the hash
         sleep(Duration::from_secs(5)).await;
 
         // Retry checking if peers have the hash
-        let mut retries = 10;
+        let mut retries = 2;
         let mut peers_have = false;
         while retries > 0 {
             peers_have = group.peers_have_hash(&file_hash).await.unwrap_or(false);
@@ -894,7 +895,7 @@ mod tests {
             .expect("Failed to create base directory");
 
         // Initialize the backend
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         // Step 1: Create a group via backend
@@ -975,7 +976,7 @@ mod tests {
             .expect("Failed to create base directory");
 
         // Initialize the backend
-        let mut backend = Backend::new(path.as_ref(), port).expect("Unable to create Backend");
+        let mut backend = Backend::new(path.as_ref()).expect("Unable to create Backend");
         backend.start().await.expect("Unable to start");
 
         // Step 1: Create a group via backend

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,8 @@ mod tests {
             .expect("Unable to create repo");
 
         let iroh_blobs = backend
-            .iroh_blobs
-            .as_ref()
+            .get_iroh_blobs()
+            .await
             .expect("iroh_blobs not initialized");
 
         // Prepare data to upload as a blob
@@ -159,7 +159,7 @@ mod tests {
             .await
             .expect(GROUP_NOT_FOUND);
 
-        let protected_store = backend.get_protected_store().unwrap();
+        let protected_store = backend.get_protected_store().await.unwrap();
         let keypair_data = protected_store
             .load_user_secret(group.id().to_string())
             .await
@@ -277,11 +277,13 @@ mod tests {
                 .expect("Unable to create repo");
             let veilid_api = backend
                 .get_veilid_api()
+                .await
                 .expect("Failed to get VeilidAPI instance");
 
             // Get the update receiver from the backend
             let update_rx = backend
                 .subscribe_updates()
+                .await
                 .expect("Failed to subscribe to updates");
 
             // Set up a channel to receive AppMessage updates
@@ -324,7 +326,7 @@ mod tests {
             println!("Sending message to owner...");
 
             // Send the message
-            repo.send_message_to_owner(veilid_api, message.clone(), ROUTE_ID_DHT_KEY)
+            repo.send_message_to_owner(&veilid_api, message.clone(), ROUTE_ID_DHT_KEY)
                 .await
                 .expect("Failed to send message to repo owner");
 
@@ -487,6 +489,7 @@ mod tests {
         // Verify that the file was uploaded and the hash was written to the DHT
         let dht_value = backend
             .get_veilid_api()
+            .await
             .expect("veilid_api not initialized")
             .routing_context()
             .expect("Failed to get routing context")
@@ -557,7 +560,7 @@ mod tests {
             .await
             .expect("Failed to write to temp file");
 
-        let protected_store = backend.get_protected_store().unwrap();
+        let protected_store = backend.get_protected_store().await.unwrap();
 
         let repo = backend.create_repo(&group.id()).await?;
 
@@ -570,6 +573,7 @@ mod tests {
         // Verify that the file was uploaded and the hash was written to the DHT
         let dht_value = backend
             .get_veilid_api()
+            .await
             .expect("veilid_api not initialized")
             .routing_context()
             .expect("Failed to get routing context")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,7 +556,7 @@ mod tests {
             .expect("veilid_api not initialized")
             .routing_context()
             .expect("Failed to get routing context")
-            .get_dht_value(group.dht_record.key().clone(), 1, false)
+            .get_dht_value(repo.dht_record.key().clone(), 1, false)
             .await
             .expect("Failed to retrieve DHT value");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -841,6 +841,11 @@ mod tests {
             .await
             .expect("Unable to join group on second peer");
 
+        assert!(
+            !new_file_collection_hash.as_bytes().is_empty(),
+            "New collection hash after uploading a file should not be empty"
+        );
+        println!("Asking peers");
         // Add delay to allow peers to propagate the hash
         sleep(Duration::from_secs(5)).await;
         println!("Asking peers!");
@@ -1043,7 +1048,6 @@ mod tests {
         let path = TmpDir::new("test_repo_collection_management")
             .await
             .unwrap();
-        let port = 8080;
         fs::create_dir_all(path.as_ref())
             .await
             .expect("Failed to create base directory");
@@ -1082,8 +1086,11 @@ mod tests {
         );
 
         // Step 6: Use iroh_blobs set_file to update the collection with the uploaded file
-        let blobs_future = backend.get_iroh_blobs().await;
-        let iroh_blobs = blobs_future.as_ref().expect("iroh_blobs not initialized");
+        let iroh_blobs = backend
+            .get_iroh_blobs()
+            .await
+            .expect("iroh_blobs not initialized");
+
         let collection_name = repo.get_name().await.expect("Failed to get repo name");
         let updated_collection_hash = repo
             .set_file_and_update_dht(&collection_name, file_name, &file_hash)
@@ -1138,7 +1145,6 @@ mod tests {
         let path = TmpDir::new("test_backend_collection_hash_consistency")
             .await
             .unwrap();
-        let port = 8080;
         fs::create_dir_all(path.as_ref())
             .await
             .expect("Failed to create base directory");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,8 +403,8 @@ mod tests {
             group.id()
         );
 
-        let loaded_group = backend.get_group(&group.id()).await.expect(GROUP_NOT_FOUND);
-        let loaded_repo = group
+        let mut loaded_group = backend.get_group(&group.id()).await.expect(GROUP_NOT_FOUND);
+        let loaded_repo = loaded_group
             .load_repo_from_disk()
             .await
             .expect("Repo not found after restart");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,8 +409,7 @@ mod tests {
 
         let mut loaded_group = backend.get_group(&group_id).await.expect(GROUP_NOT_FOUND);
         let loaded_repo = loaded_group
-            .load_repo_from_disk()
-            .await
+            .get_own_repo()
             .expect("Repo not found after restart");
 
         let retrieved_name = loaded_repo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,7 +409,8 @@ mod tests {
 
         let mut loaded_group = backend.get_group(&group_id).await.expect(GROUP_NOT_FOUND);
         let loaded_repo = loaded_group
-            .get_own_repo()
+            .load_repo_from_disk()
+            .await
             .expect("Repo not found after restart");
 
         let retrieved_name = loaded_repo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -990,7 +990,7 @@ mod tests {
         // Step 6: Use iroh_blobs set_file to update the collection with the uploaded file
         let iroh_blobs = backend.iroh_blobs.as_ref().expect("iroh_blobs not initialized");
         let collection_name = repo.get_name().await.expect("Failed to get repo name");
-        let updated_collection_hash = iroh_blobs.set_file(&collection_name, file_name, &file_hash).await?;
+        let updated_collection_hash = repo.set_file_and_update_dht(&collection_name, file_name, &file_hash).await?;
         assert!(!updated_collection_hash.as_bytes().is_empty(), "Updated collection hash should not be empty after adding file");
 
         // Step 7: Verify the file is listed in the collection

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1159,8 +1159,11 @@ mod tests {
             .await
             .expect("Unable to create group");
         let collection_name = "hash_consistency_collection".to_string();
-        let blobs_future = backend.get_iroh_blobs().await;
-        let iroh_blobs = blobs_future.as_ref().expect("iroh_blobs not initialized");
+
+        let iroh_blobs = backend
+            .get_iroh_blobs()
+            .await
+            .expect("iroh_blobs not initialized");
 
         // Step 2: Create collection and get initial hash
         let initial_collection_hash = iroh_blobs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,7 +432,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn upload_blob() -> Result<()> {
+    async fn upload_blob_test() -> Result<()> {
         let path = TmpDir::new("test_dweb_backend_upload_blob").await.unwrap();
         let port = 8081;
 
@@ -472,7 +472,7 @@ mod tests {
             .expect("veilid_api not initialized")
             .routing_context()
             .expect("Failed to get routing context")
-            .get_dht_value(group.dht_record.key().clone(), 1, false)
+            .get_dht_value(repo.dht_record.key().clone(), 1, false)
             .await
             .expect("Failed to retrieve DHT value");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,10 +154,7 @@ mod tests {
 
         backend.start().await.expect("Unable to restart");
 
-        let mut loaded_group = backend
-            .get_group(TypedKey::new(CRYPTO_KIND_VLD0, group.id()))
-            .await
-            .expect(GROUP_NOT_FOUND);
+        let mut loaded_group = backend.get_group(&group.id()).await.expect(GROUP_NOT_FOUND);
 
         let protected_store = backend.get_protected_store().await.unwrap();
         let keypair_data = protected_store
@@ -356,10 +353,7 @@ mod tests {
         backend.stop().await.expect("Unable to stop");
 
         backend.start().await.expect("Unable to restart");
-        let loaded_group = backend
-            .get_group(TypedKey::new(CRYPTO_KIND_VLD0, group.id()))
-            .await
-            .expect(GROUP_NOT_FOUND);
+        let loaded_group = backend.get_group(&group.id()).await.expect(GROUP_NOT_FOUND);
 
         let name = loaded_group
             .get_name()
@@ -409,10 +403,7 @@ mod tests {
             group.id()
         );
 
-        let loaded_group = backend
-            .get_group(TypedKey::new(CRYPTO_KIND_VLD0, group.id()))
-            .await
-            .expect(GROUP_NOT_FOUND);
+        let loaded_group = backend.get_group(&group.id()).await.expect(GROUP_NOT_FOUND);
         let loaded_repo = group
             .load_repo_from_disk()
             .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,50 +1,61 @@
-use clap::{Command, Arg};
-use anyhow::{Result, anyhow};
-use xdg::BaseDirectories;
-use tokio::fs;
 use crate::backend::Backend;
 use crate::common::{CommonKeypair, DHTEntity};
+use crate::constants::{UNABLE_TO_GET_GROUP_NAME, UNABLE_TO_SET_GROUP_NAME};
 use crate::group::Group;
 use crate::repo::Repo;
-use crate::constants::{UNABLE_TO_SET_GROUP_NAME, UNABLE_TO_GET_GROUP_NAME};
+use anyhow::{anyhow, Result};
+use clap::{Arg, Command};
+use tokio::fs;
+use xdg::BaseDirectories;
 
+mod backend;
 mod common;
+mod constants;
 mod group;
 mod repo;
-mod backend;
-mod constants;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let matches = Command::new("Save DWeb Backend")
-        .arg(Arg::new("pubkey")
-            .long("pubkey")
-            .value_name("PUBKEY")
-            .help("Sets the public key for the group")
-            .value_parser(clap::value_parser!(String)))
-        .arg(Arg::new("secret")
-            .long("seckey")
-            .value_name("SECKEY")
-            .help("Sets the secret key for the group")
-            .value_parser(clap::value_parser!(String)))
-        .arg(Arg::new("encryption_key")
-            .long("enckey")
-            .value_name("ENCKEY")
-            .help("Sets the encryption key for the group")
-            .value_parser(clap::value_parser!(String)))
+        .arg(
+            Arg::new("pubkey")
+                .long("pubkey")
+                .value_name("PUBKEY")
+                .help("Sets the public key for the group")
+                .value_parser(clap::value_parser!(String)),
+        )
+        .arg(
+            Arg::new("secret")
+                .long("seckey")
+                .value_name("SECKEY")
+                .help("Sets the secret key for the group")
+                .value_parser(clap::value_parser!(String)),
+        )
+        .arg(
+            Arg::new("encryption_key")
+                .long("enckey")
+                .value_name("ENCKEY")
+                .help("Sets the encryption key for the group")
+                .value_parser(clap::value_parser!(String)),
+        )
         .get_matches();
 
-    let path = xdg::BaseDirectories::with_prefix("save-dweb-backend")?.get_data_home();
-    let port = 8080;
+    let xdg_dirs = BaseDirectories::with_prefix("save-dweb-backend")?;
+    let base_dir = xdg_dirs.get_data_home();
 
-    fs::create_dir_all(&path).await.expect("Failed to create base directory");
+    fs::create_dir_all(&base_dir)
+        .await
+        .expect("Failed to create base directory");
 
-    let mut backend = Backend::new(&path, port)?;
+    let mut backend = Backend::new(&base_dir)?;
 
     backend.start().await?;
 
     // Check if keys were provided, otherwise create a new group
-    if matches.contains_id("pubkey") && matches.contains_id("seckey") && matches.contains_id("enckey") {
+    if matches.contains_id("pubkey")
+        && matches.contains_id("seckey")
+        && matches.contains_id("enckey")
+    {
         let pubkey = matches.get_one::<String>("pubkey").unwrap();
         let seckey = matches.get_one::<String>("seckey").unwrap();
         let enckey = matches.get_one::<String>("enckey").unwrap();
@@ -54,8 +65,14 @@ async fn main() -> anyhow::Result<()> {
     } else {
         let group = backend.create_group().await?;
         println!("Group created with Record Key: {:?}", group.id());
-        println!("Group created with Secret Key: {:?}", group.get_secret_key().unwrap());
-        println!("Group created with Encryption Key: {:?}", group.get_encryption_key());
+        println!(
+            "Group created with Secret Key: {:?}",
+            group.get_secret_key().unwrap()
+        );
+        println!(
+            "Group created with Encryption Key: {:?}",
+            group.get_encryption_key()
+        );
     }
     // Await for ctrl-c and then stop the backend
     tokio::signal::ctrl_c().await?;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -291,9 +291,8 @@ impl Repo {
         // Ensure the collection exists before uploading
         let collection_hash = self.get_or_create_collection().await?;
 
-        // Get the collection name from the collection hash if needed
-        let collection_name = self.iroh_blobs.get_name_from_hash(&collection_hash).await?;
-
+        // Use the repo name 
+        let collection_name = self.get_name().await?;
         let (tx, rx) = mpsc::channel::<std::io::Result<Bytes>>(1);
         tx.send(Ok(Bytes::from(data_to_upload.clone()))).await.unwrap();
         drop(tx);

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -22,7 +22,7 @@ pub struct Repo {
     pub dht_record: DHTRecordDescriptor,
     pub encryption_key: SharedSecret,
     pub secret_key: Option<CryptoTyped<CryptoKey>>,
-    pub routing_context: Arc<RoutingContext>,
+    pub routing_context: RoutingContext,
     pub crypto_system: CryptoSystemVLD0,
     pub iroh_blobs: VeilidIrohBlobs,
 }
@@ -32,7 +32,7 @@ impl Repo {
         dht_record: DHTRecordDescriptor,
         encryption_key: SharedSecret,
         secret_key: Option<CryptoTyped<CryptoKey>>,
-        routing_context: Arc<RoutingContext>,
+        routing_context: RoutingContext,
         crypto_system: CryptoSystemVLD0,
         iroh_blobs: VeilidIrohBlobs,
     ) -> Self {
@@ -172,7 +172,7 @@ impl DHTEntity for Repo {
         self.encryption_key.clone()
     }
 
-    fn get_routing_context(&self) -> Arc<RoutingContext> {
+    fn get_routing_context(&self) -> RoutingContext {
         self.routing_context.clone()
     }
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -263,13 +263,11 @@ impl Repo {
         // Ensure the collection exists before deleting a file
         let collection_hash = self.get_or_create_collection().await?;
 
-        // Get the collection name from the collection hash
-        let collection_name = self.iroh_blobs.get_name_from_hash(&collection_hash).await?;
-
         // Delete the file from the collection and get the new collection hash
         let deleted_hash = self.iroh_blobs.delete_file_from_collection_hash(&collection_hash, file_name).await?;
 
         // Persist the new collection hash with the name to the store
+        let collection_name = self.get_name().await?;
         self.iroh_blobs.persist_collection_with_name(&collection_name, &deleted_hash).await?;
 
         // Update the DHT with the new collection hash

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -219,9 +219,7 @@ impl Repo {
         };
 
         // Persist the collection with the name
-        if let Err(e) = self.iroh_blobs.persist_collection_with_name(&collection_name, &new_hash).await {
-            return Err(e);
-        }
+        self.iroh_blobs.persist_collection_with_name(&collection_name, &new_hash).await?;
 
         // Update the DHT with the new collection hash
         if let Err(e) = self.update_collection_on_dht().await {
@@ -244,11 +242,9 @@ impl Repo {
 
     pub async fn list_files(&self) -> Result<Vec<String>> {
         let collection_hash = if !self.can_write() {
-            let hash = self.get_hash_from_dht().await?;
-            hash
+            self.get_hash_from_dht().await?
         } else {
-            let hash = self.get_or_create_collection().await?;
-            hash
+            self.get_or_create_collection().await?
         };
     
         self.list_files_from_collection_hash(&collection_hash).await


### PR DESCRIPTION
- Backend now keeps state inside `inner` struct
- Repos only tracked under groups
- Load repos from DHT on group init
- Persist "own repo" key to storage
- enforce only creating own repo once