### PR TITLE
Update `veilid-core` to `tag = "v0.4.4"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 iroh = "0.24.0"
 iroh-blobs = "0.24.0"
-veilid-core = { git = "https://gitlab.com/veilid/veilid.git", version = "0.4.3" }
+veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.4.4" }
 veilid-iroh-blobs = { git = "https://github.com/RangerMauve/veilid-iroh-blobs.git", version = "0.1.1" }
 tracing = "0.1"
 xdg = "2.4"


### PR DESCRIPTION
 The previous configuration used `version = "0.4.3"` with git dependencies, which Cargo ignores and pulls the
  latest commit instead. This caused compatibility issues when veilid's protected store API changed between
  versions.

  - Update veilid-core dependency to pinned v0.4.4 tag