### PR TITLE
Fix/store keypair and download timeout

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: hecrj/setup-rust-action@v2
         with:
-          rust-version: stable
+          rust-version: 1.88.0
       
       - name: Check out the code
         uses: actions/checkout@v4

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: hecrj/setup-rust-action@v2
         with:
-          rust-version: 1.88.0
+          rust-version: stable
       
       - name: Check out the code
         uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,14 @@ iroh = "0.24.0"
 iroh-blobs = "0.24.0"
 # Pin to avoid keyvaluedb-sqlite 0.1.6 + rusqlite 0.38 break (u64 FromSql not implemented)
 keyvaluedb-sqlite = "=0.1.5"
+keyvaluedb = "=0.1.6"        # pin to prevent 0.1.7 which breaks keyvaluedb-sqlite 0.1.5
 rusqlite = "=0.37.0"
 veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.1" }
+veilid-tools = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.1" }
 # v0.3.0 matches Veilid 0.5.1 API
 veilid-iroh-blobs = { git = "https://github.com/RangerMauve/veilid-iroh-blobs", tag = "v0.3.0" }
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 xdg = "2.4"
 tmpdir = "1"
 serde = "1.0.204"
@@ -35,3 +38,4 @@ base64 = "0.22.1"
 # Temporary patch for Veilid fanout queue underflow bug
 [patch."https://gitlab.com/veilid/veilid.git"]
 veilid-core = { git = "https://gitlab.com/tripledoublev/veilid.git", branch = "fix-underflow" }
+veilid-tools = { git = "https://gitlab.com/tripledoublev/veilid.git", branch = "fix-underflow" }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -379,6 +379,18 @@ impl Backend {
 
         let dht_record = dht_record.ok_or_else(|| anyhow!("Group DHT record retrieval failed"))?;
 
+        // Persist the keypair so refresh_group/get_group can reload it later
+        let protected_store = veilid.protected_store().unwrap();
+        CommonKeypair {
+            id: record_key.clone(),
+            public_key: keys.public_key.clone(),
+            secret_key: keys.secret_key.clone(),
+            encryption_key: keys.encryption_key.clone(),
+        }
+        .store_keypair(&protected_store)
+        .await
+        .map_err(|e| anyhow!(e))?;
+
         let mut group = Group::new(
             dht_record.clone(),
             keys.encryption_key.clone(),

--- a/src/group.rs
+++ b/src/group.rs
@@ -138,9 +138,13 @@ impl Group {
         }
 
         // Retry configuration
-        const MAX_RETRIES: u32 = 3;
+        // Veilid route establishment + iroh tunnel setup can be transiently flaky, especially
+        // under load in CI or when routes are regenerating. Keep this bounded but resilient.
+        // Keep this bounded: higher-level callers (HTTP endpoints/tests) can retry too.
+        const MAX_RETRIES: u32 = 5;
         const INITIAL_DELAY_MS: u64 = 500;
-        const MAX_DELAY_MS: u64 = 2000;
+        const MAX_DELAY_MS: u64 = 4000;
+        const PER_PEER_TIMEOUT_SECS: u64 = 10;
 
         for attempt in 0..MAX_RETRIES {
             for repo in repos.iter() {
@@ -153,24 +157,34 @@ impl Group {
                 
                 if let Ok(route_id_blob) = repo.get_route_id_blob().await {
                     // It's faster to try and fail, than to ask then try
-                    let result = self
-                        .iroh_blobs
-                        .download_file_from(route_id_blob, hash)
-                        .await;
-                    
+                    // Guard against hung downloads so a single peer doesn't stall the whole request.
+                    let result = tokio::time::timeout(
+                        tokio::time::Duration::from_secs(PER_PEER_TIMEOUT_SECS),
+                        self.iroh_blobs.download_file_from(route_id_blob, hash),
+                    )
+                    .await;
+
                     match result {
-                        Ok(()) => {
+                        Ok(Ok(())) => {
                             info!("Successfully downloaded hash {} from peer {}",
                                 hash.to_hex(),
                                 hex::encode(repo.id().opaque().ref_value())
                             );
                             return Ok(());
                         }
-                        Err(e) => {
+                        Ok(Err(e)) => {
                             warn!(
                                 "Unable to download from peer {}: {}",
                                 hex::encode(repo.id().opaque().ref_value()),
                                 e
+                            );
+                        }
+                        Err(_) => {
+                            warn!(
+                                "Timed out downloading hash {} from peer {} after {}s",
+                                hash.to_hex(),
+                                hex::encode(repo.id().opaque().ref_value()),
+                                PER_PEER_TIMEOUT_SECS
                             );
                         }
                     }


### PR DESCRIPTION

  - Store keypair after join_group: After opening the DHT
  record on join, persist the keypair to the protected
  store so that refresh_group/get_group can reload it
  later. Without this, rejoining a group after restart
  would fail.
  - Add per-peer download timeout: Wrap download_file_from
   in a 10s timeout so a single hung peer doesn't stall
  the entire download loop.
  - Increase retry resilience: Bump max retries from 3 to
  5 and max backoff from 2s to 4s to better handle
  transient Veilid route flakiness.