### PR TITLE
Bump version and security lockfile updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,7 +490,7 @@ checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "getrandom 0.2.17",
  "instant",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2111,7 +2111,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "spinning_top",
 ]
@@ -2245,7 +2245,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
@@ -2269,7 +2269,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -2291,7 +2291,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -2673,7 +2673,7 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.32",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
  "url",
  "xmltree",
@@ -2840,7 +2840,7 @@ dependencies = [
  "postcard",
  "quic-rpc",
  "quic-rpc-derive",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ref-cast",
  "serde",
  "strum 0.25.0",
@@ -2870,7 +2870,7 @@ dependencies = [
  "iroh-blake3",
  "once_cell",
  "postcard",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "redb 2.6.3",
  "serde",
@@ -2921,7 +2921,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "postcard",
- "rand 0.8.5",
+ "rand 0.8.6",
  "range-collections",
  "redb 1.5.2",
  "redb 2.6.3",
@@ -2960,7 +2960,7 @@ dependencies = [
  "lru",
  "num_enum",
  "postcard",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "redb 1.5.2",
  "redb 2.6.3",
@@ -2994,7 +2994,7 @@ dependencies = [
  "iroh-metrics",
  "iroh-net",
  "postcard",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "serde",
  "tokio",
@@ -3079,7 +3079,7 @@ dependencies = [
  "pin-project",
  "pkarr",
  "postcard",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "rcgen",
  "reqwest",
@@ -3138,7 +3138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd0538ff12efe3d61ea1deda2d7913f4270873a519d43e6995c6e87a1558538"
 dependencies = [
  "bytes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ring",
  "rustc-hash",
  "rustls 0.23.36",
@@ -3492,7 +3492,7 @@ dependencies = [
  "ed25519-dalek",
  "flume 0.11.1",
  "lru",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_bencode",
  "serde_bytes",
@@ -3862,7 +3862,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -4672,14 +4672,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls 0.23.36",
@@ -4754,9 +4754,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4765,9 +4765,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -5223,7 +5223,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -5319,9 +5319,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "save-dweb-backend"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5392,7 +5392,7 @@ dependencies = [
  "hickory-resolver",
  "iroh",
  "iroh-blobs",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_cbor",
  "serial_test",
@@ -6155,7 +6155,7 @@ dependencies = [
  "precis-core",
  "precis-profiles",
  "quoted-string-parser",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -6173,7 +6173,7 @@ dependencies = [
  "hex",
  "parking_lot",
  "pnet_packet",
- "rand 0.9.2",
+ "rand 0.9.4",
  "socket2 0.6.2",
  "thiserror 1.0.69",
  "tokio",
@@ -6189,7 +6189,7 @@ dependencies = [
  "acto",
  "anyhow",
  "hickory-proto 0.24.4",
- "rand 0.8.5",
+ "rand 0.8.6",
  "socket2 0.5.10",
  "tokio",
  "tracing",
@@ -6414,7 +6414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4d51942bbd63241e665ca0cc613f56dfaee117b41d5288a6cb3fca5cdab2415"
 dependencies = [
  "futures",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -6730,7 +6730,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -6748,7 +6748,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -7001,7 +7001,7 @@ checksum = "ce2b3c073da0025538ff4cf5bea61a7a7a046c1bf060e2d0981c71800747551d"
 dependencies = [
  "attohttpc",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "url",
  "xmltree",
 ]
@@ -7056,7 +7056,7 @@ dependencies = [
  "netlink-sys",
  "nix 0.31.3",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.8.6",
  "range-set-blaze 0.4.4",
  "rayon",
  "rtnetlink 0.20.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "save-dweb-backend"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 
 [features]


### PR DESCRIPTION
## Summary
- bump save-dweb-backend to 0.3.6
- update Cargo.lock for resolvable Dependabot security alerts: rand 0.8.x, rand 0.9.x, quinn-proto, and rustls-webpki 0.103.x
- leave unresolved transitive alerts blocked by current Veilid/Iroh compatibility constraints

## Notes
The remaining hickory-proto, older rustls-webpki, and lru alerts cannot be cleanly resolved with a lockfile-only update. Cargo rejects the patched versions because the current graph is constrained by veilid-core/veilid-tools and the patched Iroh fork used to keep Veilid and Iroh compatible.

## Verification
- cargo check