### PR TITLE
Harden URL/DHT parsing, fix repo write credential, load nextest config

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,8 +2,9 @@
 # Veilid network tests can take several minutes due to DHT operations and network setup
 
 [profile.default]
-# Set timeout to 10 minutes per test (Veilid network operations can be slow)
-test-timeout = "600s"
+# Terminate any test still running after 10 minutes (Veilid network operations can be slow).
+# `period` sets the duration; `terminate-after = 1` kills the test after one period elapses.
+slow-timeout = { period = "600s", terminate-after = 1 }
 
 # Retry flaky tests up to 3 times
 retries = 3

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -689,11 +689,19 @@ pub fn record_key_from_query(url: &Url, key: &str) -> Result<RecordKey> {
     Ok(RecordKey::new(CRYPTO_KIND_VLD0, bare))
 }
 
-pub fn public_key_from_query(url: &Url, key: &str) -> Result<PublicKey> {
+/// Hex-decode an attacker-controlled join-URL query value into exactly 32 bytes,
+/// returning an error on bad hex or wrong length.
+fn key_bytes_from_query(url: &Url, key: &str) -> Result<[u8; 32]> {
     let value = find_query(url, key)?;
     let bytes = hex::decode(value)?;
-    let mut key_vec: [u8; 32] = [0; 32];
-    key_vec.copy_from_slice(bytes.as_slice());
+    bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow!("Expected 32-byte key for {key}, got {} bytes", bytes.len()))
+}
+
+pub fn public_key_from_query(url: &Url, key: &str) -> Result<PublicKey> {
+    let key_vec = key_bytes_from_query(url, key)?;
     Ok(PublicKey::new(
         CRYPTO_KIND_VLD0,
         veilid_core::BarePublicKey::from(&key_vec[..]),
@@ -701,10 +709,7 @@ pub fn public_key_from_query(url: &Url, key: &str) -> Result<PublicKey> {
 }
 
 pub fn secret_key_from_query(url: &Url, key: &str) -> Result<SecretKey> {
-    let value = find_query(url, key)?;
-    let bytes = hex::decode(value)?;
-    let mut key_vec: [u8; 32] = [0; 32];
-    key_vec.copy_from_slice(bytes.as_slice());
+    let key_vec = key_bytes_from_query(url, key)?;
     Ok(SecretKey::new(
         CRYPTO_KIND_VLD0,
         veilid_core::BareSecretKey::from(&key_vec[..]),
@@ -712,10 +717,7 @@ pub fn secret_key_from_query(url: &Url, key: &str) -> Result<SecretKey> {
 }
 
 pub fn shared_secret_from_query(url: &Url, key: &str) -> Result<SharedSecret> {
-    let value = find_query(url, key)?;
-    let bytes = hex::decode(value)?;
-    let mut key_vec: [u8; 32] = [0; 32];
-    key_vec.copy_from_slice(bytes.as_slice());
+    let key_vec = key_bytes_from_query(url, key)?;
     Ok(SharedSecret::new(
         CRYPTO_KIND_VLD0,
         veilid_core::BareSharedSecret::from(&key_vec[..]),

--- a/src/common.rs
+++ b/src/common.rs
@@ -229,6 +229,13 @@ pub trait DHTEntity {
             .get(CRYPTO_KIND_VLD0)
             .ok_or_else(|| anyhow!("Unable to init crypto system"))?;
 
+        // The first 24 bytes are the nonce; a shorter value can't carry one.
+        if data.len() < 24 {
+            return Err(anyhow!(
+                "Ciphertext too short: expected at least 24 bytes for nonce, got {}",
+                data.len()
+            ));
+        }
         let nonce: [u8; 24] = data[..24]
             .try_into()
             .map_err(|_| anyhow!("Failed to convert nonce slice to array"))?;

--- a/src/group.rs
+++ b/src/group.rs
@@ -257,7 +257,7 @@ impl Group {
             self.download_hash_from_peers(hash).await?
         }
 
-        let receiver = self.iroh_blobs.read_file(*hash).await.unwrap();
+        let receiver = self.iroh_blobs.read_file(*hash).await?;
 
         Ok(receiver)
     }

--- a/src/group.rs
+++ b/src/group.rs
@@ -573,7 +573,9 @@ impl Group {
         let repo = Repo::new(
             repo_dht_record.clone(),
             encryption_key.clone(),
-            self.get_secret_key(),
+            // The repo is its own DHT record with its own keypair; its owner secret is
+            // the write credential for that record.
+            repo_dht_record.owner_secret().clone(),
             self.routing_context.clone(),
             self.veilid.clone(),
             self.iroh_blobs.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -621,6 +621,49 @@ mod tests {
         backend.stop().await.expect("Unable to stop");
     }
 
+    #[test]
+    fn key_query_parsers_reject_malformed_input() {
+        use crate::group::{URL_ENCRYPTION_KEY, URL_PUBLIC_KEY, URL_SECRET_KEY};
+        use url::Url;
+
+        // 16 bytes of valid hex — decodes fine but is the wrong length for a 32-byte key.
+        let short = "00".repeat(16);
+        let url = Url::parse(&format!("save+dweb:?{URL_PUBLIC_KEY}={short}")).unwrap();
+        assert!(backend::public_key_from_query(&url, URL_PUBLIC_KEY).is_err());
+        let url = Url::parse(&format!("save+dweb:?{URL_SECRET_KEY}={short}")).unwrap();
+        assert!(backend::secret_key_from_query(&url, URL_SECRET_KEY).is_err());
+        let url = Url::parse(&format!("save+dweb:?{URL_ENCRYPTION_KEY}={short}")).unwrap();
+        assert!(backend::shared_secret_from_query(&url, URL_ENCRYPTION_KEY).is_err());
+
+        // 33 bytes — one byte too long.
+        let long = "00".repeat(33);
+        let url = Url::parse(&format!("save+dweb:?{URL_PUBLIC_KEY}={long}")).unwrap();
+        assert!(backend::public_key_from_query(&url, URL_PUBLIC_KEY).is_err());
+
+        // Not valid hex at all.
+        let url = Url::parse(&format!("save+dweb:?{URL_PUBLIC_KEY}=zzzz")).unwrap();
+        assert!(backend::public_key_from_query(&url, URL_PUBLIC_KEY).is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn decrypt_aead_rejects_short_ciphertext() -> Result<()> {
+        let (backend, _tmpdir) =
+            setup_test_backend("decrypt_aead_rejects_short_ciphertext").await?;
+        let group = backend
+            .create_group()
+            .await
+            .expect("Unable to create group");
+
+        // Fewer than 24 bytes cannot hold a nonce.
+        assert!(group.decrypt_aead(&[0u8; 10], None).is_err());
+        // Exactly the nonce length, but no ciphertext or tag follows.
+        assert!(group.decrypt_aead(&[0u8; 24], None).is_err());
+
+        backend.stop().await.expect("Unable to stop");
+        Ok(())
+    }
+
     #[tokio::test]
     #[serial]
     async fn list_repos_test() -> Result<()> {


### PR DESCRIPTION
## Summary

Four safe, self-contained fixes from a review of the group/repo key handling. No public API signatures change.

- **Parsing panics → errors.** `public_key_from_query` / `secret_key_from_query` / `shared_secret_from_query` used `copy_from_slice` into a `[u8; 32]`, panicking on a wrong-length value from an attacker-controlled join URL. Replaced with a shared `key_bytes_from_query` helper that errors on bad hex or wrong length.
- **Decrypt panic → error.** `decrypt_aead` sliced `data[..24]` with no length check, panicking on a short/hostile DHT value. Added a guard that returns an error when the value can't carry a nonce.
- **Repo write credential.** `create_repo` built the in-memory `Repo` with the group's owner secret instead of the repo record's own. Now uses `repo_dht_record.owner_secret()`, matching the `CommonKeypair` persisted alongside it.
- **Nextest config actually loads.** The root `nextest.toml` was never read (nextest loads `.config/nextest.toml`) and used the invalid `test-timeout` key. Moved to `.config/nextest.toml` and switched to `slow-timeout = { period = "600s", terminate-after = 1 }`. It now loads with no warnings, enforcing the intended 10-minute hard per-test timeout.

## Notes

- `--test-threads=1 --retries=3` in CI already matched the config values; the new effect is the hard per-test timeout now taking effect.
- Architectural items from the review (owner-secret in invite URL, backend mutex held across network I/O, slot-count repo advertisement races) were intentionally left out of this PR.

## Verification

- `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` all pass.
- `cargo nextest list` auto-loads `.config/nextest.toml` with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)