### PR TITLE
Add coverage for backend edge cases

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,8 +2,9 @@
 # Veilid network tests can take several minutes due to DHT operations and network setup
 
 [profile.default]
-# Set timeout to 10 minutes per test (Veilid network operations can be slow)
-test-timeout = "600s"
+# Terminate any test still running after 10 minutes (Veilid network operations can be slow).
+# `period` sets the duration; `terminate-after = 1` kills the test after one period elapses.
+slow-timeout = { period = "600s", terminate-after = 1 }
 
 # Retry flaky tests up to 3 times
 retries = 3

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -680,6 +680,15 @@ fn find_query(url: &Url, key: &str) -> Result<String> {
     Err(anyhow!("Unable to find parameter {key} in URL {url:?}"))
 }
 
+fn fixed_32_byte_hex_from_query(url: &Url, key: &str) -> Result<[u8; 32]> {
+    let value = find_query(url, key)?;
+    let bytes = hex::decode(&value).map_err(|e| anyhow!("Invalid hex for {key}: {e}"))?;
+    let len = bytes.len();
+    bytes.try_into().map_err(|_| {
+        anyhow!("Invalid length for {key}: expected 32 bytes from hex, got {len} bytes")
+    })
+}
+
 /// Decode a record key from a URL query parameter.
 /// Expects the value produced by `RecordKey::ref_value().encode()` (e.g. from `Group::get_url()`).
 /// Round-trip is covered by the `test_join` test.
@@ -690,10 +699,7 @@ pub fn record_key_from_query(url: &Url, key: &str) -> Result<RecordKey> {
 }
 
 pub fn public_key_from_query(url: &Url, key: &str) -> Result<PublicKey> {
-    let value = find_query(url, key)?;
-    let bytes = hex::decode(value)?;
-    let mut key_vec: [u8; 32] = [0; 32];
-    key_vec.copy_from_slice(bytes.as_slice());
+    let key_vec = fixed_32_byte_hex_from_query(url, key)?;
     Ok(PublicKey::new(
         CRYPTO_KIND_VLD0,
         veilid_core::BarePublicKey::from(&key_vec[..]),
@@ -701,10 +707,7 @@ pub fn public_key_from_query(url: &Url, key: &str) -> Result<PublicKey> {
 }
 
 pub fn secret_key_from_query(url: &Url, key: &str) -> Result<SecretKey> {
-    let value = find_query(url, key)?;
-    let bytes = hex::decode(value)?;
-    let mut key_vec: [u8; 32] = [0; 32];
-    key_vec.copy_from_slice(bytes.as_slice());
+    let key_vec = fixed_32_byte_hex_from_query(url, key)?;
     Ok(SecretKey::new(
         CRYPTO_KIND_VLD0,
         veilid_core::BareSecretKey::from(&key_vec[..]),
@@ -712,10 +715,7 @@ pub fn secret_key_from_query(url: &Url, key: &str) -> Result<SecretKey> {
 }
 
 pub fn shared_secret_from_query(url: &Url, key: &str) -> Result<SharedSecret> {
-    let value = find_query(url, key)?;
-    let bytes = hex::decode(value)?;
-    let mut key_vec: [u8; 32] = [0; 32];
-    key_vec.copy_from_slice(bytes.as_slice());
+    let key_vec = fixed_32_byte_hex_from_query(url, key)?;
     Ok(SharedSecret::new(
         CRYPTO_KIND_VLD0,
         veilid_core::BareSharedSecret::from(&key_vec[..]),
@@ -736,4 +736,102 @@ pub fn parse_url(url_string: &str) -> Result<CommonKeypair> {
         secret_key,
         encryption_key,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::{test_helpers::setup_test_backend, DHTEntity};
+    use serial_test::serial;
+
+    fn encoded_record_key(byte: u8) -> String {
+        let bytes = [byte; 32];
+        RecordKey::new(
+            CRYPTO_KIND_VLD0,
+            veilid_core::BareRecordKey::new(
+                veilid_core::BareOpaqueRecordKey::from(&bytes[..]),
+                None,
+            ),
+        )
+        .ref_value()
+        .encode()
+    }
+
+    fn valid_url_with(pk: &str) -> String {
+        let dht = encoded_record_key(1);
+        let enc = "22".repeat(32);
+        let sk = "33".repeat(32);
+        format!("save+dweb::?dht={dht}&enc={enc}&pk={pk}&sk={sk}")
+    }
+
+    fn parse_url_err(url: &str) -> String {
+        match parse_url(url) {
+            Ok(_) => panic!("expected URL parse error"),
+            Err(err) => err.to_string(),
+        }
+    }
+
+    #[test]
+    fn parse_url_rejects_malformed_url() {
+        assert!(parse_url("not a url").is_err());
+    }
+
+    #[test]
+    fn parse_url_rejects_missing_query_parameters() {
+        let err = parse_url_err("save+dweb::?");
+        assert!(err.contains("dht"));
+    }
+
+    #[test]
+    fn parse_url_rejects_short_hex_key_without_panicking() {
+        let err = parse_url_err(&valid_url_with("abcd"));
+        assert!(err.contains("pk"));
+        assert!(err.contains("expected 32 bytes"));
+    }
+
+    #[test]
+    fn parse_url_rejects_non_hex_key_without_panicking() {
+        let err = parse_url_err(&valid_url_with("not-hex"));
+        assert!(err.contains("Invalid hex for pk"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn refresh_group_reloads_group_after_cache_invalidation() -> Result<()> {
+        let (backend, _tmpdir) =
+            setup_test_backend("refresh_group_reloads_group_after_cache_invalidation").await?;
+        let group = backend.create_group().await?;
+        let group_id = group.id();
+        group.set_name("Refreshable").await?;
+
+        let refreshed = backend.refresh_group(&group_id).await?;
+
+        assert_eq!(refreshed.id(), group_id);
+        assert_eq!(refreshed.get_name().await?, "Refreshable");
+
+        backend.stop().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn close_group_removes_group_from_cache() -> Result<()> {
+        let (backend, _tmpdir) = setup_test_backend("close_group_removes_group_from_cache").await?;
+        let group = backend.create_group().await?;
+        let group_id = group.id();
+
+        assert_eq!(backend.list_groups().await?.len(), 1);
+
+        backend.close_group(group_id.clone()).await?;
+        assert!(backend.list_groups().await?.is_empty());
+
+        let err = backend
+            .close_group(group_id)
+            .await
+            .expect_err("closing a removed group should fail");
+        assert!(err.to_string().contains("Group not found"));
+
+        backend.stop().await?;
+        Ok(())
+    }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -689,11 +689,19 @@ pub fn record_key_from_query(url: &Url, key: &str) -> Result<RecordKey> {
     Ok(RecordKey::new(CRYPTO_KIND_VLD0, bare))
 }
 
-pub fn public_key_from_query(url: &Url, key: &str) -> Result<PublicKey> {
+/// Hex-decode an attacker-controlled join-URL query value into exactly 32 bytes,
+/// returning an error on bad hex or wrong length.
+fn key_bytes_from_query(url: &Url, key: &str) -> Result<[u8; 32]> {
     let value = find_query(url, key)?;
     let bytes = hex::decode(value)?;
-    let mut key_vec: [u8; 32] = [0; 32];
-    key_vec.copy_from_slice(bytes.as_slice());
+    bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow!("Expected 32-byte key for {key}, got {} bytes", bytes.len()))
+}
+
+pub fn public_key_from_query(url: &Url, key: &str) -> Result<PublicKey> {
+    let key_vec = key_bytes_from_query(url, key)?;
     Ok(PublicKey::new(
         CRYPTO_KIND_VLD0,
         veilid_core::BarePublicKey::from(&key_vec[..]),
@@ -701,10 +709,7 @@ pub fn public_key_from_query(url: &Url, key: &str) -> Result<PublicKey> {
 }
 
 pub fn secret_key_from_query(url: &Url, key: &str) -> Result<SecretKey> {
-    let value = find_query(url, key)?;
-    let bytes = hex::decode(value)?;
-    let mut key_vec: [u8; 32] = [0; 32];
-    key_vec.copy_from_slice(bytes.as_slice());
+    let key_vec = key_bytes_from_query(url, key)?;
     Ok(SecretKey::new(
         CRYPTO_KIND_VLD0,
         veilid_core::BareSecretKey::from(&key_vec[..]),
@@ -712,10 +717,7 @@ pub fn secret_key_from_query(url: &Url, key: &str) -> Result<SecretKey> {
 }
 
 pub fn shared_secret_from_query(url: &Url, key: &str) -> Result<SharedSecret> {
-    let value = find_query(url, key)?;
-    let bytes = hex::decode(value)?;
-    let mut key_vec: [u8; 32] = [0; 32];
-    key_vec.copy_from_slice(bytes.as_slice());
+    let key_vec = key_bytes_from_query(url, key)?;
     Ok(SharedSecret::new(
         CRYPTO_KIND_VLD0,
         veilid_core::BareSharedSecret::from(&key_vec[..]),

--- a/src/common.rs
+++ b/src/common.rs
@@ -16,6 +16,28 @@ use veilid_core::{
 
 use crate::constants::ROUTE_ID_DHT_KEY;
 
+pub(crate) const AEAD_NONCE_LEN: usize = 24;
+
+pub(crate) fn split_aead_payload(data: &[u8]) -> Result<([u8; AEAD_NONCE_LEN], &[u8])> {
+    if data.len() < AEAD_NONCE_LEN {
+        return Err(anyhow!(
+            "Encrypted payload too short: expected at least {AEAD_NONCE_LEN} bytes for nonce, got {}",
+            data.len()
+        ));
+    }
+
+    let (nonce_bytes, encrypted_data) = data.split_at(AEAD_NONCE_LEN);
+    if encrypted_data.is_empty() {
+        return Err(anyhow!("Encrypted payload has no ciphertext"));
+    }
+
+    let nonce = nonce_bytes
+        .try_into()
+        .map_err(|_| anyhow!("Failed to convert nonce slice to array"))?;
+
+    Ok((nonce, encrypted_data))
+}
+
 #[cfg(test)]
 pub mod test_helpers {
     use super::*;
@@ -229,11 +251,8 @@ pub trait DHTEntity {
             .get(CRYPTO_KIND_VLD0)
             .ok_or_else(|| anyhow!("Unable to init crypto system"))?;
 
-        let nonce: [u8; 24] = data[..24]
-            .try_into()
-            .map_err(|_| anyhow!("Failed to convert nonce slice to array"))?;
+        let (nonce, encrypted_data) = split_aead_payload(data)?;
         let nonce = Nonce::new(&nonce);
-        let encrypted_data = &data[24..];
         crypto_system
             .decrypt_aead(
                 encrypted_data,
@@ -353,5 +372,34 @@ pub trait DHTEntity {
 
     async fn leave(&self) -> Result<()> {
         unimplemented!("WIP")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_aead_payload_rejects_short_ciphertext() {
+        let err = split_aead_payload(b"short").expect_err("short payload should fail");
+        assert!(err.to_string().contains("too short"));
+    }
+
+    #[test]
+    fn split_aead_payload_rejects_missing_ciphertext() {
+        let payload = [0u8; AEAD_NONCE_LEN];
+        let err = split_aead_payload(&payload).expect_err("nonce-only payload should fail");
+        assert!(err.to_string().contains("no ciphertext"));
+    }
+
+    #[test]
+    fn split_aead_payload_returns_nonce_and_ciphertext() {
+        let mut payload = vec![7u8; AEAD_NONCE_LEN];
+        payload.extend_from_slice(b"ciphertext");
+
+        let (nonce, ciphertext) = split_aead_payload(&payload).expect("payload should split");
+
+        assert_eq!(nonce, [7u8; AEAD_NONCE_LEN]);
+        assert_eq!(ciphertext, b"ciphertext");
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -229,6 +229,13 @@ pub trait DHTEntity {
             .get(CRYPTO_KIND_VLD0)
             .ok_or_else(|| anyhow!("Unable to init crypto system"))?;
 
+        // The first 24 bytes are the nonce; a shorter value can't carry one.
+        if data.len() < 24 {
+            return Err(anyhow!(
+                "Ciphertext too short: expected at least 24 bytes for nonce, got {}",
+                data.len()
+            ));
+        }
         let nonce: [u8; 24] = data[..24]
             .try_into()
             .map_err(|_| anyhow!("Failed to convert nonce slice to array"))?;

--- a/src/group.rs
+++ b/src/group.rs
@@ -257,7 +257,7 @@ impl Group {
             self.download_hash_from_peers(hash).await?
         }
 
-        let receiver = self.iroh_blobs.read_file(*hash).await.unwrap();
+        let receiver = self.iroh_blobs.read_file(*hash).await?;
 
         Ok(receiver)
     }

--- a/src/group.rs
+++ b/src/group.rs
@@ -3,6 +3,7 @@ use crate::repo::Repo;
 use crate::{common::DHTEntity, repo};
 use anyhow::{anyhow, Error, Result};
 use bytes::Bytes;
+use futures_util::future::join_all;
 use hex::ToHex;
 use iroh::net::key::SecretKey as IrohSecretKey;
 use iroh_blobs::Hash;
@@ -32,6 +33,85 @@ pub const URL_DHT_KEY: &str = "dht";
 pub const URL_ENCRYPTION_KEY: &str = "enc";
 pub const URL_PUBLIC_KEY: &str = "pk";
 pub const URL_SECRET_KEY: &str = "sk";
+pub const MAX_GROUP_REPOS: u32 = 64;
+
+#[derive(Debug, PartialEq, Eq)]
+enum RepoAdvertisementSlot {
+    AlreadyPresent(u32),
+    Open(u32),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RepoAdvertisementVerification {
+    Verified,
+    Missing,
+    Collision,
+}
+
+fn choose_repo_advertisement_slot<'a, I>(slots: I, repo_key: &[u8]) -> Result<RepoAdvertisementSlot>
+where
+    I: IntoIterator<Item = (u32, Option<&'a [u8]>)>,
+{
+    let mut first_open = None;
+
+    for (subkey, value) in slots {
+        if !(1..=MAX_GROUP_REPOS).contains(&subkey) {
+            continue;
+        }
+
+        match value {
+            Some(existing) if existing == repo_key => {
+                return Ok(RepoAdvertisementSlot::AlreadyPresent(subkey));
+            }
+            Some(_) => {}
+            None if first_open.is_none() => first_open = Some(subkey),
+            None => {}
+        }
+    }
+
+    first_open
+        .map(RepoAdvertisementSlot::Open)
+        .ok_or_else(|| anyhow!("No free repo advertisement slots in group DHT record"))
+}
+
+fn verify_repo_advertisement(
+    stored_value: Option<&[u8]>,
+    repo_key: &[u8],
+) -> RepoAdvertisementVerification {
+    match stored_value {
+        Some(value) if value == repo_key => RepoAdvertisementVerification::Verified,
+        Some(_) => RepoAdvertisementVerification::Collision,
+        None => RepoAdvertisementVerification::Missing,
+    }
+}
+
+fn repo_watch_subkey_bounds() -> (u32, u32) {
+    (1, MAX_GROUP_REPOS)
+}
+
+fn repo_record_key_from_dht_bytes(data: &[u8]) -> Result<RecordKey> {
+    if data.len() == 32 {
+        // Legacy (pre-Veilid-0.5.1): raw 32-byte opaque key from old advertise_own_repo.
+        // Supports mixed groups where some peers have not yet upgraded.
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(data);
+        return Ok(RecordKey::new(
+            CRYPTO_KIND_VLD0,
+            veilid_core::BareRecordKey::new(veilid_core::BareOpaqueRecordKey::from(&arr[..]), None),
+        ));
+    }
+
+    if let Ok(s) = String::from_utf8(data.to_vec()) {
+        let bare_key = veilid_core::BareRecordKey::try_decode(&s)
+            .map_err(|e| anyhow!("Failed to decode repo record key: {e}"))?;
+        return Ok(RecordKey::new(CRYPTO_KIND_VLD0, bare_key));
+    }
+
+    Err(anyhow!(
+        "Repo key on DHT is neither legacy 32-byte nor valid UTF-8 encoded key (len={})",
+        data.len()
+    ))
+}
 
 #[derive(Clone)]
 pub struct Group {
@@ -296,35 +376,59 @@ impl Group {
         Ok(url.to_string())
     }
 
-    async fn dht_repo_count(&self) -> Result<usize> {
-        let dht_record = &self.dht_record;
-        let range = ValueSubkeyRangeSet::full();
+    async fn load_repo_advertisement_slots(
+        &self,
+        include_open_slot: bool,
+    ) -> Result<Vec<(u32, Option<Vec<u8>>)>> {
+        let range = ValueSubkeyRangeSet::single_range(1, MAX_GROUP_REPOS);
         let scope = DHTReportScope::UpdateGet;
-
-        let record_key = dht_record.key().clone();
-
         let report = self
             .routing_context
-            .inspect_dht_record(record_key.clone(), Some(range), scope)
+            .inspect_dht_record(self.dht_record.key().clone(), Some(range), scope)
             .await?;
 
-        let size = report.network_seqs().len();
+        let mut subkeys_to_read = Vec::new();
+        let mut first_open_slot = None;
+        for ((subkey, local_seq), network_seq) in report
+            .subkeys()
+            .iter()
+            .zip(report.local_seqs())
+            .zip(report.network_seqs())
+        {
+            if !(1..=MAX_GROUP_REPOS).contains(&subkey) {
+                continue;
+            }
 
-        let mut count = 0;
-
-        while count + 1 < size {
-            let value = self
-                .routing_context
-                .get_dht_value(record_key.clone(), (count + 1).try_into()?, true)
-                .await?;
-            if value.is_some() {
-                count += 1;
-            } else {
-                return Ok(count);
+            if local_seq.is_some() || network_seq.is_some() {
+                subkeys_to_read.push(subkey);
+            } else if include_open_slot && first_open_slot.is_none() {
+                first_open_slot = Some(subkey);
             }
         }
 
-        Ok(count)
+        let record_key = self.dht_record.key().clone();
+        let reads = subkeys_to_read.into_iter().map(|subkey| {
+            let routing_context = self.routing_context.clone();
+            let record_key = record_key.clone();
+            async move {
+                let value = routing_context
+                    .get_dht_value(record_key, subkey, true)
+                    .await?
+                    .map(|value| value.data().to_vec());
+                Ok::<_, anyhow::Error>((subkey, value))
+            }
+        });
+
+        let mut slots = Vec::with_capacity(MAX_GROUP_REPOS as usize);
+        for result in join_all(reads).await {
+            slots.push(result?);
+        }
+        if let Some(subkey) = first_open_slot {
+            slots.push((subkey, None));
+        }
+        slots.sort_by_key(|(subkey, _)| *subkey);
+
+        Ok(slots)
     }
 
     pub async fn advertise_own_repo(&self) -> Result<()> {
@@ -337,30 +441,89 @@ impl Group {
         // joining devices can decrypt the repo's DHT values.
         let repo_key = repo.id().ref_value().encode().into_bytes();
 
-        let count = self.dht_repo_count().await? + 1;
+        for _attempt in 0..MAX_GROUP_REPOS {
+            let slots = self.load_repo_advertisement_slots(true).await?;
+            let decision = choose_repo_advertisement_slot(
+                slots
+                    .iter()
+                    .map(|(subkey, value)| (*subkey, value.as_deref())),
+                &repo_key,
+            )?;
 
-        info!(
-            "Advertising own repo {} to group {} at subkey {}",
-            hex::encode(repo.id().opaque().ref_value()),
-            hex::encode(self.id().opaque().ref_value()),
-            count
-        );
+            let subkey = match decision {
+                RepoAdvertisementSlot::AlreadyPresent(subkey) => {
+                    info!(
+                        "Own repo {} already advertised in group {} at subkey {}",
+                        hex::encode(repo.id().opaque().ref_value()),
+                        hex::encode(self.id().opaque().ref_value()),
+                        subkey
+                    );
+                    return Ok(());
+                }
+                RepoAdvertisementSlot::Open(subkey) => subkey,
+            };
 
-        self.routing_context
-            .set_dht_value(
-                self.dht_record.key().clone(),
-                count.try_into()?,
-                repo_key,
-                Some(SetDHTValueOptions::default()),
-            )
-            .await?;
+            info!(
+                "Advertising own repo {} to group {} at subkey {}",
+                hex::encode(repo.id().opaque().ref_value()),
+                hex::encode(self.id().opaque().ref_value()),
+                subkey
+            );
 
-        info!(
-            "Successfully advertised own repo {} to group",
-            hex::encode(repo.id().opaque().ref_value())
-        );
+            if let Some(conflict) = self
+                .routing_context
+                .set_dht_value(
+                    self.dht_record.key().clone(),
+                    subkey,
+                    repo_key.clone(),
+                    Some(SetDHTValueOptions::default()),
+                )
+                .await?
+            {
+                if conflict.data() != repo_key.as_slice() {
+                    warn!(
+                        "Repo advertisement slot {} collided while setting; retrying",
+                        subkey
+                    );
+                    continue;
+                }
+            }
 
-        Ok(())
+            let stored_value = self
+                .routing_context
+                .get_dht_value(self.dht_record.key().clone(), subkey, true)
+                .await?;
+
+            match verify_repo_advertisement(
+                stored_value.as_ref().map(|value| value.data()),
+                &repo_key,
+            ) {
+                RepoAdvertisementVerification::Verified => {
+                    info!(
+                        "Successfully advertised own repo {} to group at subkey {}",
+                        hex::encode(repo.id().opaque().ref_value()),
+                        subkey
+                    );
+                    return Ok(());
+                }
+                RepoAdvertisementVerification::Missing => {
+                    warn!(
+                        "Repo advertisement slot {} was still empty; retrying",
+                        subkey
+                    );
+                }
+                RepoAdvertisementVerification::Collision => {
+                    warn!(
+                        "Repo advertisement slot {} was claimed by another repo; retrying",
+                        subkey
+                    );
+                }
+            }
+        }
+
+        Err(anyhow!(
+            "Unable to advertise own repo without a repo-slot collision after {MAX_GROUP_REPOS} attempts"
+        ))
     }
 
     pub async fn load_repo_from_network(
@@ -426,36 +589,8 @@ impl Group {
         Ok(repo)
     }
 
-    async fn load_repo_from_dht(&mut self, subkey: u32) -> Result<RecordKey> {
-        let repo_id_raw = self
-            .routing_context
-            .get_dht_value(self.dht_record.key().clone(), subkey, true)
-            .await?
-            .ok_or_else(|| anyhow!("Unable to load repo ID from DHT"))?;
-
-        let data = repo_id_raw.data();
-        let repo_id = if data.len() == 32 {
-            // Legacy (pre-Veilid-0.5.1): raw 32-byte opaque key from old advertise_own_repo.
-            // Supports mixed groups where some peers have not yet upgraded.
-            let mut arr = [0u8; 32];
-            arr.copy_from_slice(data);
-            RecordKey::new(
-                CRYPTO_KIND_VLD0,
-                veilid_core::BareRecordKey::new(
-                    veilid_core::BareOpaqueRecordKey::from(&arr[..]),
-                    None,
-                ),
-            )
-        } else if let Ok(s) = String::from_utf8(data.to_vec()) {
-            let bare_key = veilid_core::BareRecordKey::try_decode(&s)
-                .map_err(|e| anyhow!("Failed to decode repo record key: {e}"))?;
-            RecordKey::new(CRYPTO_KIND_VLD0, bare_key)
-        } else {
-            return Err(anyhow!(
-                "Repo key on DHT is neither legacy 32-byte nor valid UTF-8 encoded key (len={})",
-                data.len()
-            ));
-        };
+    async fn load_repo_from_dht_value(&mut self, data: &[u8]) -> Result<RecordKey> {
+        let repo_id = repo_record_key_from_dht_bytes(data)?;
 
         let cache_key = Self::repo_cache_key(&repo_id);
         if self.repos.lock().await.contains_key(&cache_key) {
@@ -467,15 +602,15 @@ impl Group {
     }
 
     pub async fn load_repos_from_dht(&mut self) -> Result<()> {
-        let count = self.dht_repo_count().await?;
+        for (subkey, value) in self.load_repo_advertisement_slots(false).await? {
+            let Some(repo_id_raw) = value else {
+                continue;
+            };
 
-        let mut i = 1;
-        while i <= count {
-            info!("Loading from DHT {i}");
-            if let Err(e) = self.load_repo_from_dht(i.try_into()?).await {
-                warn!("Warning: Failed to load repo {i} from DHT: {e:?}");
+            match self.load_repo_from_dht_value(&repo_id_raw).await {
+                Ok(_) => info!("Loaded repo from DHT subkey {subkey}"),
+                Err(e) => warn!("Warning: Failed to load repo {subkey} from DHT: {e:?}"),
             }
-            i += 1;
         }
 
         Ok(())
@@ -636,17 +771,8 @@ impl Group {
         F: Fn() -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<()>> + Send + 'static,
     {
-        let repo_count = self.dht_repo_count().await?;
-        let range = if repo_count > 0 {
-            ValueSubkeyRangeSet::single_range(0, repo_count as u32 - 1)
-        } else {
-            ValueSubkeyRangeSet::full()
-        };
-
-        let expiration_duration = 600_000_000;
-        let expiration =
-            SystemTime::now().duration_since(UNIX_EPOCH)?.as_micros() as u64 + expiration_duration;
-        let count = 0;
+        let (start, end) = repo_watch_subkey_bounds();
+        let range = ValueSubkeyRangeSet::single_range(start, end);
 
         // Clone necessary data for the async block
         let routing_context = self.routing_context.clone();
@@ -710,5 +836,114 @@ impl DHTEntity for Group {
 
     fn get_secret_key(&self) -> Option<SecretKey> {
         self.owner_secret()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encoded_record_key(byte: u8) -> String {
+        let bytes = [byte; 32];
+        RecordKey::new(
+            CRYPTO_KIND_VLD0,
+            veilid_core::BareRecordKey::new(
+                veilid_core::BareOpaqueRecordKey::from(&bytes[..]),
+                None,
+            ),
+        )
+        .ref_value()
+        .encode()
+    }
+
+    #[test]
+    fn repo_advertisement_slot_reuses_existing_slot_for_same_repo() {
+        let repo_key = b"repo-a";
+        let decision =
+            choose_repo_advertisement_slot([(1, Some(repo_key.as_slice())), (2, None)], repo_key)
+                .expect("slot should resolve");
+
+        assert_eq!(decision, RepoAdvertisementSlot::AlreadyPresent(1));
+    }
+
+    #[test]
+    fn repo_advertisement_slot_finds_existing_repo_after_hole() {
+        let repo_key = b"repo-a";
+        let other_repo = b"repo-b";
+        let decision = choose_repo_advertisement_slot(
+            [
+                (1, Some(other_repo.as_slice())),
+                (2, None),
+                (3, Some(repo_key.as_slice())),
+            ],
+            repo_key,
+        )
+        .expect("slot should resolve");
+
+        assert_eq!(decision, RepoAdvertisementSlot::AlreadyPresent(3));
+    }
+
+    #[test]
+    fn concurrent_repo_slot_collision_retries_next_open_slot() {
+        let repo_key = b"repo-a";
+        let other_repo = b"repo-b";
+        let first = choose_repo_advertisement_slot(
+            [(1, None), (2, None), (3, Some(other_repo.as_slice()))],
+            repo_key,
+        )
+        .expect("first open slot should resolve");
+        assert_eq!(first, RepoAdvertisementSlot::Open(1));
+
+        let verification =
+            verify_repo_advertisement(Some(other_repo.as_slice()), repo_key.as_slice());
+        assert_eq!(verification, RepoAdvertisementVerification::Collision);
+
+        let retry = choose_repo_advertisement_slot(
+            [
+                (1, Some(other_repo.as_slice())),
+                (2, None),
+                (3, Some(other_repo.as_slice())),
+            ],
+            repo_key,
+        )
+        .expect("retry slot should resolve");
+        assert_eq!(retry, RepoAdvertisementSlot::Open(2));
+    }
+
+    #[test]
+    fn repo_slot_verification_detects_missing_value() {
+        assert_eq!(
+            verify_repo_advertisement(None, b"repo-a"),
+            RepoAdvertisementVerification::Missing
+        );
+    }
+
+    #[test]
+    fn repo_watch_changes_scans_all_repo_slots_without_group_name_slot() {
+        assert_eq!(repo_watch_subkey_bounds(), (1, MAX_GROUP_REPOS));
+    }
+
+    #[test]
+    fn repo_record_key_from_dht_bytes_accepts_encoded_record_key() {
+        let encoded = encoded_record_key(8);
+        let decoded = repo_record_key_from_dht_bytes(encoded.as_bytes())
+            .expect("encoded record key should parse");
+
+        assert_eq!(decoded.ref_value().encode(), encoded);
+    }
+
+    #[test]
+    fn repo_record_key_from_dht_bytes_accepts_legacy_opaque_key() {
+        let legacy = [9u8; 32];
+        let decoded = repo_record_key_from_dht_bytes(&legacy).expect("legacy key should parse");
+
+        assert_eq!(decoded.opaque().ref_value().bytes().as_ref(), &legacy);
+    }
+
+    #[test]
+    fn repo_record_key_from_dht_bytes_rejects_corrupted_value() {
+        let err = repo_record_key_from_dht_bytes(&[0xff, 0xfe, 0xfd])
+            .expect_err("invalid dht value should fail");
+        assert!(err.to_string().contains("valid UTF-8"));
     }
 }

--- a/src/group.rs
+++ b/src/group.rs
@@ -573,7 +573,9 @@ impl Group {
         let repo = Repo::new(
             repo_dht_record.clone(),
             encryption_key.clone(),
-            self.get_secret_key(),
+            // The repo is its own DHT record with its own keypair; its owner secret is
+            // the write credential for that record.
+            repo_dht_record.owner_secret().clone(),
             self.routing_context.clone(),
             self.veilid.clone(),
             self.iroh_blobs.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -621,6 +621,49 @@ mod tests {
         backend.stop().await.expect("Unable to stop");
     }
 
+    #[test]
+    fn key_query_parsers_reject_malformed_input() {
+        use crate::group::{URL_ENCRYPTION_KEY, URL_PUBLIC_KEY, URL_SECRET_KEY};
+        use url::Url;
+
+        // 16 bytes of valid hex — decodes fine but is the wrong length for a 32-byte key.
+        let short = "00".repeat(16);
+        let url = Url::parse(&format!("save+dweb:?{URL_PUBLIC_KEY}={short}")).unwrap();
+        assert!(backend::public_key_from_query(&url, URL_PUBLIC_KEY).is_err());
+        let url = Url::parse(&format!("save+dweb:?{URL_SECRET_KEY}={short}")).unwrap();
+        assert!(backend::secret_key_from_query(&url, URL_SECRET_KEY).is_err());
+        let url = Url::parse(&format!("save+dweb:?{URL_ENCRYPTION_KEY}={short}")).unwrap();
+        assert!(backend::shared_secret_from_query(&url, URL_ENCRYPTION_KEY).is_err());
+
+        // 33 bytes — one byte too long.
+        let long = "00".repeat(33);
+        let url = Url::parse(&format!("save+dweb:?{URL_PUBLIC_KEY}={long}")).unwrap();
+        assert!(backend::public_key_from_query(&url, URL_PUBLIC_KEY).is_err());
+
+        // Not valid hex at all.
+        let url = Url::parse(&format!("save+dweb:?{URL_PUBLIC_KEY}=zzzz")).unwrap();
+        assert!(backend::public_key_from_query(&url, URL_PUBLIC_KEY).is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn decrypt_aead_rejects_short_ciphertext() -> Result<()> {
+        let (backend, _tmpdir) =
+            setup_test_backend("decrypt_aead_rejects_short_ciphertext").await?;
+        let group = backend
+            .create_group()
+            .await
+            .expect("Unable to create group");
+
+        // Fewer than 24 bytes cannot hold a nonce.
+        assert!(group.decrypt_aead(&[0u8; 10], None).is_err());
+        // Exactly the nonce length, but no ciphertext or tag follows.
+        assert!(group.decrypt_aead(&[0u8; 24], None).is_err());
+
+        backend.stop().await.expect("Unable to stop");
+        Ok(())
+    }
+
     #[tokio::test]
     #[serial]
     async fn list_repos_test() -> Result<()> {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -22,6 +22,65 @@ use veilid_iroh_blobs::iroh::VeilidIrohBlobs;
 
 pub const HASH_SUBKEY: u32 = 1;
 pub const ROUTE_SUBKEY: u32 = 2;
+pub const ENCRYPTED_FILE_MAGIC: &[u8; 4] = b"SAVE";
+const ENCRYPTED_FILE_VERSION: u8 = 0x01;
+const ENCRYPTED_FILE_HEADER_LEN: usize = 4 + 1 + crate::common::AEAD_NONCE_LEN;
+
+enum FileDataEnvelope<'a> {
+    Plaintext(&'a [u8]),
+    Encrypted { nonce: Nonce, ciphertext: &'a [u8] },
+}
+
+fn split_file_data_envelope(data: &[u8]) -> Result<FileDataEnvelope<'_>> {
+    if data.len() < ENCRYPTED_FILE_MAGIC.len() || &data[..4] != ENCRYPTED_FILE_MAGIC {
+        return Ok(FileDataEnvelope::Plaintext(data));
+    }
+
+    if data.len() <= ENCRYPTED_FILE_HEADER_LEN {
+        return Ok(FileDataEnvelope::Plaintext(data));
+    }
+
+    let version = data[4];
+    if version != ENCRYPTED_FILE_VERSION {
+        return Err(anyhow!("Unsupported encryption version: {version}"));
+    }
+
+    let nonce_bytes: [u8; crate::common::AEAD_NONCE_LEN] = data[5..ENCRYPTED_FILE_HEADER_LEN]
+        .try_into()
+        .map_err(|_| anyhow!("Failed to extract nonce"))?;
+    let ciphertext = &data[ENCRYPTED_FILE_HEADER_LEN..];
+    Ok(FileDataEnvelope::Encrypted {
+        nonce: Nonce::new(&nonce_bytes),
+        ciphertext,
+    })
+}
+
+fn hash_from_dht_bytes(data: &[u8]) -> Result<Hash> {
+    let decoded_hash = decode(data).map_err(|e| {
+        anyhow!("Failed to decode hex string from DHT: {e}. Repo hash may be corrupted.")
+    })?;
+
+    if decoded_hash.len() != 32 {
+        return Err(anyhow!(
+            "Invalid hash length: expected 32 bytes, got {} bytes. Repo hash may be corrupted.",
+            decoded_hash.len()
+        ));
+    }
+
+    let hash_raw: [u8; 32] = decoded_hash
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow!("Invalid hash length after validation"))?;
+
+    Ok(Hash::from_bytes(hash_raw))
+}
+
+fn ensure_write_permissions(can_write: bool) -> Result<()> {
+    if !can_write {
+        return Err(anyhow::Error::msg("Repo does not have write permissions"));
+    }
+    Ok(())
+}
 
 #[derive(Clone)]
 pub struct Repo {
@@ -193,30 +252,7 @@ impl Repo {
             match value {
                 Some(v) => {
                     // Successfully got value, decode and return
-                    let data = v.data();
-
-                    // Decode the hex string (64 bytes) into a 32-byte hash
-                    let decoded_hash = match decode(data) {
-                        Ok(h) => h,
-                        Err(e) => {
-                            return Err(anyhow!(
-                                "Failed to decode hex string from DHT: {e}. Repo hash may be corrupted."
-                            ));
-                        }
-                    };
-
-                    // Ensure the decoded hash is 32 bytes
-                    if decoded_hash.len() != 32 {
-                        return Err(anyhow!(
-                            "Invalid hash length: expected 32 bytes, got {} bytes. Repo hash may be corrupted.",
-                            decoded_hash.len()
-                        ));
-                    }
-                    let mut hash_raw: [u8; 32] = [0; 32];
-                    hash_raw.copy_from_slice(&decoded_hash);
-
-                    // Now create the Hash object
-                    let hash = Hash::from_bytes(hash_raw);
+                    let hash = hash_from_dht_bytes(v.data())?;
 
                     info!("Successfully retrieved hash from DHT: {}", hash.to_hex());
                     return Ok(hash);
@@ -250,6 +286,10 @@ impl Repo {
         self.update_hash_on_dht(&collection_hash).await
     }
 
+    /// Upload a raw Iroh blob and publish its hash to DHT.
+    ///
+    /// This intentionally stores the file bytes as-is. Use [`Repo::upload`] for
+    /// encrypted, named files that are tracked in the repo collection.
     pub async fn upload_blob(&self, file_path: PathBuf) -> Result<Hash> {
         if !self.can_write() {
             return Err(anyhow!("Cannot upload blob, repo is not writable"));
@@ -424,9 +464,6 @@ impl Repo {
     /// Encrypt file data with group's encryption key
     /// Format: [MAGIC(4)] [VERSION(1)] [NONCE(24)] [ENCRYPTED_DATA]
     fn encrypt_file_data(&self, data: &[u8]) -> Result<Vec<u8>> {
-        const MAGIC: &[u8; 4] = b"SAVE"; // Magic bytes to identify encrypted files
-        const VERSION: u8 = 0x01; // Encryption version
-
         let veilid = self.get_veilid_api();
         let crypto = veilid.crypto()?;
         let crypto_system = crypto
@@ -440,8 +477,8 @@ impl Repo {
 
         // Build encrypted file: MAGIC + VERSION + NONCE + ENCRYPTED_DATA
         let mut buffer = Vec::with_capacity(4 + 1 + nonce.bytes().len() + encrypted_chunk.len());
-        buffer.extend_from_slice(MAGIC);
-        buffer.push(VERSION);
+        buffer.extend_from_slice(ENCRYPTED_FILE_MAGIC);
+        buffer.push(ENCRYPTED_FILE_VERSION);
         buffer.extend_from_slice(&nonce.bytes());
         buffer.extend_from_slice(&encrypted_chunk);
 
@@ -451,39 +488,30 @@ impl Repo {
     /// Decrypt file data, auto-detecting encrypted vs plaintext
     /// Returns (decrypted_data, was_encrypted)
     pub fn decrypt_file_data(&self, data: &[u8]) -> Result<(Vec<u8>, bool)> {
-        const MAGIC: &[u8; 4] = b"SAVE";
-
-        // Check if file is encrypted (has magic bytes)
-        if data.len() > 29 && &data[0..4] == MAGIC {
-            let version = data[4];
-            if version != 0x01 {
-                return Err(anyhow!("Unsupported encryption version: {version}"));
+        match split_file_data_envelope(data)? {
+            FileDataEnvelope::Plaintext(plaintext) => {
+                // File is not encrypted (legacy/migration case)
+                warn!("File not encrypted, returning plaintext data");
+                Ok((plaintext.to_vec(), false))
             }
+            FileDataEnvelope::Encrypted { nonce, ciphertext } => {
+                let veilid = self.get_veilid_api();
+                let crypto = veilid.crypto()?;
+                let crypto_system = crypto
+                    .get(CRYPTO_KIND_VLD0)
+                    .ok_or_else(|| anyhow!("Unable to init crypto system"))?;
 
-            let nonce_bytes: [u8; 24] = data[5..29]
-                .try_into()
-                .map_err(|_| anyhow!("Failed to extract nonce"))?;
-            let nonce = Nonce::new(&nonce_bytes);
-            let encrypted_data = &data[29..];
+                let decrypted = crypto_system
+                    .decrypt_aead(ciphertext, &nonce, &self.get_encryption_key(), None)
+                    .map_err(|e| anyhow!("Failed to decrypt file data: {e}"))?;
 
-            let veilid = self.get_veilid_api();
-            let crypto = veilid.crypto()?;
-            let crypto_system = crypto
-                .get(CRYPTO_KIND_VLD0)
-                .ok_or_else(|| anyhow!("Unable to init crypto system"))?;
-
-            let decrypted = crypto_system
-                .decrypt_aead(encrypted_data, &nonce, &self.get_encryption_key(), None)
-                .map_err(|e| anyhow!("Failed to decrypt file data: {e}"))?;
-
-            Ok((decrypted, true))
-        } else {
-            // File is not encrypted (legacy/migration case)
-            warn!("File not encrypted, returning plaintext data");
-            Ok((data.to_vec(), false))
+                Ok((decrypted, true))
+            }
         }
     }
 
+    /// Upload a named file to the repo collection after wrapping it in the
+    /// group encryption envelope (`SAVE` magic, version, nonce, ciphertext).
     pub async fn upload(&self, file_name: &str, data_to_upload: Vec<u8>) -> Result<Hash> {
         self.check_write_permissions()?;
 
@@ -548,10 +576,7 @@ impl Repo {
 
     // Helper method to check if the repo can write
     fn check_write_permissions(&self) -> Result<()> {
-        if !self.can_write() {
-            return Err(anyhow::Error::msg("Repo does not have write permissions"));
-        }
-        Ok(())
+        ensure_write_permissions(self.can_write())
     }
 }
 
@@ -578,5 +603,90 @@ impl DHTEntity for Repo {
 
     fn get_secret_key(&self) -> Option<SecretKey> {
         self.secret_key.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn envelope_err(data: &[u8]) -> String {
+        match split_file_data_envelope(data) {
+            Ok(_) => panic!("expected envelope error"),
+            Err(err) => err.to_string(),
+        }
+    }
+
+    #[test]
+    fn hash_from_dht_bytes_rejects_non_hex() {
+        let err = hash_from_dht_bytes(b"not hex").expect_err("non-hex hash should fail");
+        assert!(err.to_string().contains("Failed to decode hex string"));
+    }
+
+    #[test]
+    fn hash_from_dht_bytes_rejects_short_hash() {
+        let err = hash_from_dht_bytes(b"abcd").expect_err("short hash should fail");
+        assert!(err.to_string().contains("expected 32 bytes"));
+    }
+
+    #[test]
+    fn hash_from_dht_bytes_accepts_32_byte_hash_hex() {
+        let hex_hash = "11".repeat(32);
+        let hash = hash_from_dht_bytes(hex_hash.as_bytes()).expect("valid hash should parse");
+        assert_eq!(hash.as_bytes(), &[0x11; 32]);
+    }
+
+    #[test]
+    fn encrypted_file_envelope_accepts_short_save_prefixed_plaintext() {
+        match split_file_data_envelope(b"SAVE\x01short").expect("short legacy file should parse") {
+            FileDataEnvelope::Plaintext(data) => assert_eq!(data, b"SAVE\x01short"),
+            FileDataEnvelope::Encrypted { .. } => {
+                panic!("short SAVE-prefixed data must remain plaintext")
+            }
+        }
+    }
+
+    #[test]
+    fn encrypted_file_envelope_accepts_header_only_plaintext() {
+        let mut payload = Vec::from(&ENCRYPTED_FILE_MAGIC[..]);
+        payload.push(ENCRYPTED_FILE_VERSION);
+        payload.extend_from_slice(&[0u8; crate::common::AEAD_NONCE_LEN]);
+
+        match split_file_data_envelope(&payload).expect("header-only legacy file should parse") {
+            FileDataEnvelope::Plaintext(data) => assert_eq!(data, payload.as_slice()),
+            FileDataEnvelope::Encrypted { .. } => {
+                panic!("header-only SAVE-prefixed data must remain plaintext")
+            }
+        }
+    }
+
+    #[test]
+    fn encrypted_file_envelope_rejects_unsupported_version_with_ciphertext() {
+        let mut payload = Vec::from(&ENCRYPTED_FILE_MAGIC[..]);
+        payload.push(0x02);
+        payload.extend_from_slice(&[0u8; crate::common::AEAD_NONCE_LEN]);
+        payload.push(1);
+
+        let err = envelope_err(&payload);
+        assert!(err.contains("Unsupported encryption version"));
+    }
+
+    #[test]
+    fn encrypted_file_envelope_accepts_legacy_plaintext() {
+        match split_file_data_envelope(b"legacy plaintext").expect("plaintext should parse") {
+            FileDataEnvelope::Plaintext(data) => assert_eq!(data, b"legacy plaintext"),
+            FileDataEnvelope::Encrypted { .. } => panic!("plaintext must not be encrypted"),
+        }
+    }
+
+    #[test]
+    fn write_permission_guard_rejects_read_only_repo() {
+        let err = ensure_write_permissions(false).expect_err("read-only repo should fail");
+        assert!(err.to_string().contains("write permissions"));
+    }
+
+    #[test]
+    fn write_permission_guard_accepts_writable_repo() {
+        ensure_write_permissions(true).expect("writable repo should pass");
     }
 }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -155,38 +155,7 @@ impl RpcClient {
         payload.extend_from_slice(&message);
 
         let response = self.routing_context.app_call(target, payload).await?;
-
-        if response.is_empty() {
-            return Err(anyhow!("Empty response received from RPC call"));
-        }
-
-        let response_message_type = response[0];
-        let payload = &response[1..];
-
-        if response_message_type == MESSAGE_TYPE_ERROR {
-            let rpc_response: RpcResponse<()> = serde_cbor::from_slice(payload)?;
-            if let Some(err) = rpc_response.error {
-                return Err(anyhow!("RPC Error: {err}"));
-            } else {
-                return Err(anyhow!("Unknown error format in RPC response"));
-            }
-        }
-
-        if response_message_type != message_type {
-            return Err(anyhow!(
-                "Unexpected message type in response. Expected: {message_type}, Got: {response_message_type}"
-            ));
-        }
-
-        let rpc_response: RpcResponse<R> = serde_cbor::from_slice(payload)?;
-
-        if let Some(data) = rpc_response.success {
-            return Ok(data);
-        }
-
-        Err(anyhow!(
-            "RPC Response is missing both success and error fields"
-        ))
+        decode_rpc_response(&response, message_type)
     }
 
     pub async fn get_name(&self) -> Result<String> {
@@ -367,7 +336,7 @@ impl RpcService {
     /// Rebuild our private route after veilid reports it dead. Update the local
     /// route_id first so incoming calls are immediately accepted, then publish
     /// the new blob to DHT so clients discover it on their next fetch.
-    async fn rebuild_route(&self) -> Result<()> {
+    pub(crate) async fn rebuild_route(&self) -> Result<()> {
         let veilid = self
             .backend
             .get_veilid_api()
@@ -517,14 +486,12 @@ impl RpcService {
         message_type: u8,
         response: &RpcResponse<T>,
     ) -> Result<()> {
-        let mut response_buf = vec![message_type];
-        let payload = serde_cbor::to_vec(response)?;
+        let response_buf = encode_rpc_response(message_type, response)?;
+        let payload_len = response_buf.len().saturating_sub(1);
         info!(
             "Sending RPC response: type={}, payload_len={}",
-            message_type,
-            payload.len()
+            message_type, payload_len
         );
-        response_buf.extend_from_slice(&payload);
 
         self.backend
             .get_veilid_api()
@@ -583,7 +550,10 @@ impl RpcService {
         match backend.list_groups().await {
             Ok(groups) => RpcResponse {
                 success: Some(ListGroupsResponse {
-                    group_ids: groups.iter().map(|g| g.id().to_string()).collect(),
+                    group_ids: groups
+                        .iter()
+                        .map(|group| group_id_to_rpc_string(&group.id()))
+                        .collect(),
                 }),
                 error: None,
             },
@@ -603,33 +573,15 @@ impl RpcService {
 
         let backend = self.backend.clone();
 
-        let group_bytes = match URL_SAFE_NO_PAD.decode(&group_id) {
-            Ok(bytes) => bytes,
+        let group_key = match parse_remove_group_id(&group_id) {
+            Ok(group_key) => group_key,
             Err(err) => {
                 return RpcResponse {
                     success: None,
-                    error: Some(format!("Failed to decode group ID: {err}")),
+                    error: Some(err.to_string()),
                 };
             }
         };
-
-        let group_bytes: [u8; 32] = match group_bytes.try_into() {
-            Ok(bytes) => bytes,
-            Err(v) => {
-                return RpcResponse {
-                    success: None,
-                    error: Some(format!("Expected 32 bytes, got {}", v.len())),
-                };
-            }
-        };
-
-        let group_key = RecordKey::new(
-            CRYPTO_KIND_VLD0,
-            veilid_core::BareRecordKey::new(
-                veilid_core::BareOpaqueRecordKey::from(&group_bytes[..]),
-                None,
-            ),
-        );
 
         match backend.close_group(group_key).await {
             Ok(_) => RpcResponse {
@@ -704,6 +656,81 @@ async fn download(group: &Group, hash: &Hash) -> Result<()> {
     group.download_hash_from_peers(hash).await
 }
 
+fn encode_rpc_response<T: Serialize>(
+    message_type: u8,
+    response: &RpcResponse<T>,
+) -> Result<Vec<u8>> {
+    let mut response_buf = vec![message_type];
+    let payload = serde_cbor::to_vec(response)?;
+    response_buf.extend_from_slice(&payload);
+    Ok(response_buf)
+}
+
+fn decode_rpc_response<R: for<'de> Deserialize<'de>>(
+    response: &[u8],
+    expected_message_type: u8,
+) -> Result<R> {
+    if response.is_empty() {
+        return Err(anyhow!("Empty response received from RPC call"));
+    }
+
+    let response_message_type = response[0];
+    let payload = &response[1..];
+
+    if response_message_type == MESSAGE_TYPE_ERROR {
+        let rpc_response: RpcResponse<()> = serde_cbor::from_slice(payload)?;
+        if let Some(err) = rpc_response.error {
+            return Err(anyhow!("RPC Error: {err}"));
+        } else {
+            return Err(anyhow!("Unknown error format in RPC response"));
+        }
+    }
+
+    if response_message_type != expected_message_type {
+        return Err(anyhow!(
+            "Unexpected message type in response. Expected: {expected_message_type}, Got: {response_message_type}"
+        ));
+    }
+
+    let rpc_response: RpcResponse<R> = serde_cbor::from_slice(payload)?;
+
+    if let Some(data) = rpc_response.success {
+        return Ok(data);
+    }
+
+    Err(anyhow!(
+        "RPC Response is missing both success and error fields"
+    ))
+}
+
+fn parse_remove_group_id(group_id: &str) -> Result<RecordKey> {
+    match URL_SAFE_NO_PAD.decode(group_id) {
+        Ok(group_bytes) => {
+            let len = group_bytes.len();
+            let group_bytes: [u8; 32] = group_bytes
+                .try_into()
+                .map_err(|_| anyhow!("Expected 32 bytes, got {len}"))?;
+
+            Ok(RecordKey::new(
+                CRYPTO_KIND_VLD0,
+                veilid_core::BareRecordKey::new(
+                    veilid_core::BareOpaqueRecordKey::from(&group_bytes[..]),
+                    None,
+                ),
+            ))
+        }
+        Err(decode_err) => RecordKey::try_from(group_id).map_err(|parse_err| {
+            anyhow!(
+                "Failed to decode group ID: {decode_err}; failed to parse record key: {parse_err}"
+            )
+        }),
+    }
+}
+
+fn group_id_to_rpc_string(group_id: &RecordKey) -> String {
+    URL_SAFE_NO_PAD.encode(group_id.opaque().ref_value().bytes())
+}
+
 impl DHTEntity for RpcServiceDescriptor {
     async fn set_name(&self, name: &str) -> Result<()> {
         let routing_context = self.get_routing_context();
@@ -737,5 +764,157 @@ impl DHTEntity for RpcServiceDescriptor {
 
     fn get_veilid_api(&self) -> VeilidAPI {
         self.veilid.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::test_helpers::setup_test_backend;
+    use serial_test::serial;
+
+    fn err_string<T>(result: Result<T>) -> String {
+        match result {
+            Ok(_) => panic!("expected error"),
+            Err(err) => err.to_string(),
+        }
+    }
+
+    #[test]
+    fn rpc_join_response_wire_roundtrip_decodes_success() {
+        let response = RpcResponse {
+            success: Some(JoinGroupResponse {
+                status_message: "joined".to_string(),
+            }),
+            error: None,
+        };
+        let wire = encode_rpc_response(MESSAGE_TYPE_JOIN_GROUP, &response)
+            .expect("response should encode");
+
+        let decoded: JoinGroupResponse =
+            decode_rpc_response(&wire, MESSAGE_TYPE_JOIN_GROUP).expect("response should decode");
+
+        assert_eq!(decoded.status_message, "joined");
+    }
+
+    #[test]
+    fn rpc_remove_response_wire_roundtrip_decodes_success() {
+        let response = RpcResponse {
+            success: Some(RemoveGroupResponse {
+                status_message: "removed".to_string(),
+            }),
+            error: None,
+        };
+        let wire = encode_rpc_response(MESSAGE_TYPE_REMOVE_GROUP, &response)
+            .expect("response should encode");
+
+        let decoded: RemoveGroupResponse =
+            decode_rpc_response(&wire, MESSAGE_TYPE_REMOVE_GROUP).expect("response should decode");
+
+        assert_eq!(decoded.status_message, "removed");
+    }
+
+    #[test]
+    fn rpc_response_wire_roundtrip_surfaces_error() {
+        let response: RpcResponse<()> = RpcResponse {
+            success: None,
+            error: Some("boom".to_string()),
+        };
+        let wire = encode_rpc_response(MESSAGE_TYPE_ERROR, &response).expect("error should encode");
+
+        let message = err_string(decode_rpc_response::<JoinGroupResponse>(
+            &wire,
+            MESSAGE_TYPE_JOIN_GROUP,
+        ));
+
+        assert!(message.contains("RPC Error: boom"));
+    }
+
+    #[test]
+    fn rpc_response_decode_rejects_unexpected_message_type() {
+        let response = RpcResponse {
+            success: Some(JoinGroupResponse {
+                status_message: "joined".to_string(),
+            }),
+            error: None,
+        };
+        let wire = encode_rpc_response(MESSAGE_TYPE_JOIN_GROUP, &response)
+            .expect("response should encode");
+
+        let message = err_string(decode_rpc_response::<RemoveGroupResponse>(
+            &wire,
+            MESSAGE_TYPE_REMOVE_GROUP,
+        ));
+
+        assert!(message.contains("Unexpected message type"));
+    }
+
+    #[test]
+    fn parse_remove_group_id_rejects_malformed_base64() {
+        let err = parse_remove_group_id("not base64!").expect_err("invalid base64 should fail");
+        assert!(err.to_string().contains("Failed to decode group ID"));
+    }
+
+    #[test]
+    fn parse_remove_group_id_rejects_short_id() {
+        let short = URL_SAFE_NO_PAD.encode([1u8; 4]);
+        let err = parse_remove_group_id(&short).expect_err("short ID should fail");
+        assert!(err.to_string().contains("Expected 32 bytes"));
+    }
+
+    #[test]
+    fn parse_remove_group_id_accepts_32_byte_id() {
+        let encoded = URL_SAFE_NO_PAD.encode([4u8; 32]);
+        let key = parse_remove_group_id(&encoded).expect("32-byte ID should parse");
+
+        assert_eq!(key.opaque().ref_value().bytes().as_ref(), &[4u8; 32]);
+    }
+
+    #[test]
+    fn listed_group_id_roundtrips_through_remove_parser() {
+        let key = RecordKey::new(
+            CRYPTO_KIND_VLD0,
+            veilid_core::BareRecordKey::new(
+                veilid_core::BareOpaqueRecordKey::from(&[5u8; 32][..]),
+                None,
+            ),
+        );
+
+        let listed = group_id_to_rpc_string(&key);
+        let parsed = parse_remove_group_id(&listed).expect("listed ID should parse");
+
+        assert_eq!(parsed, key);
+    }
+
+    #[test]
+    fn parse_remove_group_id_accepts_record_key_display_for_compatibility() {
+        let key = RecordKey::new(
+            CRYPTO_KIND_VLD0,
+            veilid_core::BareRecordKey::new(
+                veilid_core::BareOpaqueRecordKey::from(&[6u8; 32][..]),
+                None,
+            ),
+        );
+
+        let parsed = parse_remove_group_id(&key.to_string()).expect("record key should parse");
+
+        assert_eq!(parsed, key);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn rpc_route_rebuild_updates_published_route_blob() -> Result<()> {
+        let (backend, _tmpdir) =
+            setup_test_backend("rpc_route_rebuild_updates_published_route_blob").await?;
+        let rpc = RpcService::from_backend(&backend).await?;
+        let before = rpc.descriptor.get_route_id_blob().await?;
+
+        rpc.rebuild_route().await?;
+
+        let after = rpc.descriptor.get_route_id_blob().await?;
+        assert_ne!(before, after);
+
+        backend.stop().await?;
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- add hermetic unit coverage for malformed URLs, DHT parsing, ciphertext envelopes, permissions, repo-slot collision handling, and RPC response parsing
- harden URL/key/hash parsing and encrypted payload handling so bad inputs return errors instead of panicking
- make group repo advertisement/load logic sparse-slot aware and keep RPC list/remove group IDs roundtrippable

## Validation
- cargo fmt
- cargo test --lib group::tests
- cargo test --lib repo::tests
- cargo test --lib parse_remove_group_id
- cargo test --lib listed_group_id_roundtrips_through_remove_parser
- timeout 120 cargo test --lib refresh_group_reloads_group_after_cache_invalidation -- --nocapture
- cargo test --lib --no-run
- cargo check
- git diff --check

Full cargo test --lib was not run because the existing suite is network-heavy and slow.