### PR TITLE
Bump veilid-iroh-blobs to 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "save-dweb-backend"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7008,14 +7008,15 @@ dependencies = [
 
 [[package]]
 name = "veilid-iroh-blobs"
-version = "0.3.4"
-source = "git+https://github.com/RangerMauve/veilid-iroh-blobs?tag=v0.3.4#62c64886942f78ef0855fa97c529c240e809eca2"
+version = "0.3.5"
+source = "git+https://github.com/RangerMauve/veilid-iroh-blobs?tag=v0.3.5#79c00a342691f12d01af426c271b93bfa9f1cf64"
 dependencies = [
  "anyhow",
  "bytes",
  "futures-lite",
  "futures-util",
  "hex",
+ "hickory-resolver",
  "iroh-blobs",
  "iroh-io",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "save-dweb-backend"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 
 [features]
@@ -23,9 +23,8 @@ iroh-blobs = "0.24.0"
 hickory-resolver = "=0.25.2"
 veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.3" }
 veilid-tools = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.3" }
-# v0.3.4 matches Veilid 0.5.3 API (improved DHT reliability and bootstrap,
-# stricter tunnel app-call validation -- see RangerMauve/veilid-iroh-blobs#12)
-veilid-iroh-blobs = { git = "https://github.com/RangerMauve/veilid-iroh-blobs", tag = "v0.3.4" }
+# Matches Veilid 0.5.3.
+veilid-iroh-blobs = { git = "https://github.com/RangerMauve/veilid-iroh-blobs", tag = "v0.3.5" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 xdg = "2.4"


### PR DESCRIPTION
## Summary
- bump save-dweb-backend package version to 0.3.8
- update veilid-iroh-blobs from v0.3.4 to v0.3.5
- refresh Cargo.lock to the v0.3.5 tag, which includes the blob transfer reliability fixes

## Local verification
- cargo check

Longer integration checks are expected to run in GitHub Actions after opening this PR.